### PR TITLE
Type references

### DIFF
--- a/jastx-test/tests/type-reference.test.tsx
+++ b/jastx-test/tests/type-reference.test.tsx
@@ -1,0 +1,107 @@
+import { expect, test } from "vitest";
+
+test("t:ref renders with a simple identifier", () => {
+  const v = (
+    <t:ref>
+      <ident name="X" />
+    </t:ref>
+  );
+
+  expect(v.render()).toBe("X");
+});
+
+test("t:ref renders with generics", () => {
+  const v = (
+    <t:ref>
+      <ident name="X" />
+      <t:primitive type="unknown" />
+      <t:ref>
+        <ident name="Y" />
+      </t:ref>
+    </t:ref>
+  );
+
+  expect(v.render()).toBe("X<unknown,Y>");
+});
+
+test("t:ref renders with literal primitive generics", () => {
+  const v = (
+    <t:ref>
+      <ident name="X" />
+      <l:string value="test" />
+      <l:number value={10} />
+      <l:boolean value={true} />
+    </t:ref>
+  );
+
+  expect(v.render()).toBe('X<"test",10,true>');
+});
+
+test.skip("t:ref renders with literal type generics", () => {
+  // TODO: Type literal is basically a type object like
+  // { name: string };
+  // const v = (
+  //   <t:ref>
+  //   </t:ref>
+  // );
+  // expect(v.render()).toBe("X<{ name: string }>");
+});
+
+test.skip("t:ref renders with tuple type generics", () => {
+  // TODO: Tuple type is basically a type array like
+  // [string, number];
+  // They also support being inside a parent "Type Operator" which
+  // allows a readonly flag:
+  // readonly [string, number];
+  //
+  // const v = (
+  //   <t:ref>
+  //   </t:ref>
+  // );
+  // expect(v.render()).toBe("X<[string, number]>");
+});
+test.skip("t:ref renders with indexed types", () => {
+  // TODO: Indexed type is basically a like
+  // T[number];
+  //
+  // const v = (
+  //   <t:ref>
+  //   </t:ref>
+  // );
+  // expect(v.render()).toBe("X<T[number]>");
+});
+
+test("t:ref throws an error with no children", () => {
+  expect(() => (
+    //@ts-expect-error
+    <t:ref></t:ref>
+  )).toThrowError();
+});
+
+test("t:ref throws an error with no identifier", () => {
+  expect(() => (
+    <t:ref>
+      <t:primitive type="unknown" />
+    </t:ref>
+  )).toThrowError();
+});
+
+test("t:ref throws an error with an out-of-order identifier", () => {
+  expect(() => (
+    <t:ref>
+      <t:primitive type="unknown" />
+      <ident name="X" />
+    </t:ref>
+  )).toThrowError();
+});
+
+test("t:ref throws an error with a non-type, non literal primitive child", () => {
+  expect(() => (
+    <t:ref>
+      <ident name="X" />
+      <bind:array-elem>
+        <ident name="x" />
+      </bind:array-elem>
+    </t:ref>
+  )).toThrowError();
+});

--- a/jastx/src/child-walker.ts
+++ b/jastx/src/child-walker.ts
@@ -20,6 +20,21 @@ export function createChildWalker(
     get remainingChildren() {
       return children;
     },
+
+    get remainingChildTypes() {
+      return Array.from(
+        new Set(
+          children.map((a) => {
+            if (typeof a === "string") {
+              return `<text [${a}]>`;
+            }
+
+            return a.type;
+          })
+        )
+      );
+    },
+
     spliceAssertGroup: (
       type: ElementType | ElementType[],
       options?: AssertGroupOptions

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -70,6 +70,10 @@ import {
   TypePrimitiveProps,
 } from "./builders/type-primitive.js";
 import {
+  createTypeReference,
+  TypeReferenceProps,
+} from "./builders/type-reference.js";
+import {
   createVariableDeclarationList,
   VariableDeclarationListProps,
 } from "./builders/variable-declaration-list.js";
@@ -136,8 +140,12 @@ export const jsxs = <T>(
         return createObjectLiteral(options as ObjectLiteralProps);
       case "l:array":
         return createArrayLiteral(options as ArrayLiteralProps);
+
       case "t:primitive":
         return createTypePrimitive(options as TypePrimitiveProps);
+      case "t:ref":
+        return createTypeReference(options as TypeReferenceProps);
+
       case "expr:non-null":
         return createNonNullExpression(options as NonNullExpressionProps);
       case "expr:prop-access":
@@ -215,6 +223,7 @@ declare global {
       ["l:object-prop"]: ObjectPropertyProps;
 
       ["t:primitive"]: TypePrimitiveProps;
+      ["t:ref"]: TypeReferenceProps;
 
       ["ident"]: IdentifierProps;
       ["exact-literal"]: ExactLiteralProps;


### PR DESCRIPTION
This is the basic building block for type values

````typescript
// X is a type reference
type T = X; 
type T = X[number]

// X, T, B, C are all type references (this is a conditional type)
type T = X extends T ? B : C;

// X and Y are type references
const a = getStuff<X>(value as Y);
```