### PR TITLE
Partial block generation

### DIFF
--- a/jastx-test/tests/block.test.tsx
+++ b/jastx-test/tests/block.test.tsx
@@ -1,0 +1,50 @@
+import { InvalidExportedMembersError } from "jastx";
+import { expect, test } from "vitest";
+
+test("block renders correctly with variable statements", () => {
+  const v = (
+    <block>
+      <var:statement>
+        <var:declaration-list type="const">
+          <var:declaration>
+            <ident name="x" />
+            <t:primitive type="string" />
+            <l:string value="Hello" />
+          </var:declaration>
+        </var:declaration-list>
+      </var:statement>
+      <var:statement>
+        <var:declaration-list type="let">
+          <var:declaration>
+            <ident name="c" />
+          </var:declaration>
+        </var:declaration-list>
+      </var:statement>
+    </block>
+  );
+
+  expect(v.render()).toBe('{const x:string="Hello";let c;}');
+});
+
+test("block throws an error if it includes exported statements", () => {
+  expect(() => (
+    <block>
+      <var:statement>
+        <var:declaration-list type="const">
+          <var:declaration>
+            <ident name="x" />
+            <t:primitive type="string" />
+            <l:string value="Hello" />
+          </var:declaration>
+        </var:declaration-list>
+      </var:statement>
+      <var:statement exported={true}>
+        <var:declaration-list type="let">
+          <var:declaration>
+            <ident name="c" />
+          </var:declaration>
+        </var:declaration-list>
+      </var:statement>
+    </block>
+  )).toThrow();
+});

--- a/jastx/package.json
+++ b/jastx/package.json
@@ -5,11 +5,11 @@
   "license": "ISC",
   "author": "",
   "type": "module",
-  "module": "./dist/types.js",
-  "types": "./dist/types.d.ts",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "default": "./dist/types.js"
+      "default": "./dist/index.js"
     },
     "./jsx-runtime": "./dist/jsx-runtime.js",
     "./jsx-dev-runtime": "./dist/jsx-runtime.js"

--- a/jastx/src/builders/blocks.ts
+++ b/jastx/src/builders/blocks.ts
@@ -1,0 +1,48 @@
+import { createChildWalker } from "../child-walker.js";
+import {
+  InvalidChildrenError,
+  InvalidExportedMembersError,
+} from "../errors.js";
+import { AstNode, BLOCK_STATEMENTS_AND_DECLARATIONS } from "../types.js";
+import { isVariableStatement } from "./variable-statement.js";
+
+const type = "block";
+
+export interface BlockProps {
+  children: any;
+}
+
+export interface BlockNode extends AstNode {
+  type: typeof type;
+  props: BlockProps;
+}
+
+const allowed_types = [...BLOCK_STATEMENTS_AND_DECLARATIONS];
+
+export function createBlock(props: BlockProps): BlockNode {
+  const walker = createChildWalker(type, props);
+
+  const statements = walker.spliceAssertGroup(allowed_types);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      allowed_types,
+      Array.from(new Set(walker.remainingChildren.map((a) => a.type)))
+    );
+  }
+
+  const modified_statements = statements.filter(
+    (a) => isVariableStatement(a) && a.props.exported
+  );
+
+  if (modified_statements.length > 0) {
+    throw new InvalidExportedMembersError(type, modified_statements);
+  }
+
+  return {
+    type: type,
+    props,
+    render: () => `{${statements.map((a) => a.render()).join(";")};}`,
+  };
+}

--- a/jastx/src/builders/variable-statement.ts
+++ b/jastx/src/builders/variable-statement.ts
@@ -14,6 +14,10 @@ export interface VariableStatementNode extends AstNode {
   props: VariableStatementProps;
 }
 
+export function isVariableStatement(v: AstNode): v is VariableStatementNode {
+  return v.type === "var:statement";
+}
+
 export function createVariableStatement(
   props: VariableStatementProps
 ): VariableStatementNode {

--- a/jastx/src/errors.ts
+++ b/jastx/src/errors.ts
@@ -1,3 +1,5 @@
+import { AstNode } from "./types.js";
+
 export class InvalidSyntaxError extends Error {}
 
 export class LhsInvalidTypeError extends InvalidSyntaxError {
@@ -33,6 +35,19 @@ export class InvalidChildrenError extends InvalidSyntaxError {
         .join("\n")}\nbut found:\n\n${actualTypes
         .map((a) => `- <${a}>`)
         .join("\n")} instead.`
+    );
+  }
+}
+
+export class InvalidExportedMembersError extends InvalidSyntaxError {
+  constructor(
+    sourceType: string,
+    elements: (AstNode & { props: { exported: true } })[]
+  ) {
+    super(
+      `<${sourceType}> can not contain exported members, found the following:\n${elements
+        .map((a) => `- ${a.render()}`)
+        .join("\n")}`
     );
   }
 }

--- a/jastx/src/index.ts
+++ b/jastx/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./errors.js";
+export * from "./types.js";

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -12,6 +12,7 @@ import {
   ObjectBindingElementProps,
   ObjectBindingProps,
 } from "./builders/binding.js";
+import { BlockProps, createBlock } from "./builders/blocks.js";
 import {
   CallExpressionProps,
   createCallExpression,
@@ -120,6 +121,9 @@ export const jsxs = <T>(
     switch (element) {
       case "ident":
         return createIdentifier(options as IdentifierProps);
+      case "block":
+        return createBlock(options as BlockProps);
+
       case "exact-literal":
         return createExactLiteral(options as ExactLiteralProps);
       case "var:declaration":
@@ -240,6 +244,8 @@ declare global {
       ["t:indexed"]: TypeIndexedProps;
 
       ["ident"]: IdentifierProps;
+      ["block"]: BlockProps;
+
       ["exact-literal"]: ExactLiteralProps;
       ["var:declaration"]: VariableDeclarationProps;
       ["var:declaration-list"]: VariableDeclarationListProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -54,6 +54,7 @@ export type TypeElementType = `t:${TypeElementTypeName}`;
 export type ElementType =
   | "ident"
   | "text"
+  | "block"
   | "var:statement"
   | "var:declaration"
   | "var:declaration-list"
@@ -107,6 +108,10 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:indexed",
 ];
 
+export const BLOCK_STATEMENTS_AND_DECLARATIONS: readonly ElementType[] = [
+  "var:statement",
+];
+
 export function isTypeType(v: string) {
   return TYPE_TYPES.includes(v as TypeElementType);
 }
@@ -121,6 +126,7 @@ export const ANY_TYPE = [...EXPRESSION_OR_LITERAL_TYPES, ...TYPE_TYPES];
 export type AstNode = {
   type: ElementType;
   docs?: AstNode;
+  props: any; // TODO: Make this more accurate
   render: () => string;
 };
 


### PR DESCRIPTION
This is an early version of block syntax. Block syntax is to be used in a variety of places:

Functions
```typescript
function a () 
// this part is the block
{
   ...
}

const b = () => 
// this part is the block
{
  ... 
}
```

If/else statements
```typescript
if (condition)
// This part is the block
{
  ...
}
```

And more. It's basically creates a new scope in which statements and declarations can be defined. This will be seperate to the top level scope, as the top level scope can include a number of additional things, such as exports/imports and module declarations. The top-level scope may also not allow `await` syntax (depending on whether the file is a module or a script)