### PR TITLE
Add function expressions and declarations

### DIFF
--- a/jastx-test/tests/function-declaration.test.tsx
+++ b/jastx-test/tests/function-declaration.test.tsx
@@ -1,0 +1,201 @@
+import { expect, test } from "vitest";
+
+test("function-declaration renders correctly", () => {
+  const v1 = (
+    <function-declaration>
+      <ident name="test" />
+      <block />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe("function test(){}");
+});
+
+test("function-declaration renders correctly without a body", () => {
+  // This is only for overloads, it's a bit shaky about how it's actually valid
+  // we would need to compare siblings to see if this actually overloads another
+  // function because overloads need to be declared next to each other.
+  //
+  // We could possibly break with typescript's AST here and declarably force something
+  // like
+  // <function-declaration>
+  //   <function-declaration-overload>
+  //      ...type params, params and return values
+  //   </function-declaration-overload>
+  //   <ident name="test" />
+  //   ...rest
+  //
+  const v1 = (
+    <function-declaration>
+      <ident name="test" />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe("function test()");
+});
+
+test("function-declaration renders with parameters", () => {
+  const v1 = (
+    <function-declaration>
+      <ident name="test" />
+      <param>
+        <ident name="a" />
+      </param>
+      <param>
+        <ident name="b" />
+        <t:primitive type="string" />
+      </param>
+      <param>
+        <ident name="c" />
+        <t:primitive type="string" />
+        <l:string value="hello" />
+      </param>
+      <block />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe('function test(a,b:string,c:string="hello"){}');
+});
+
+test("function-declaration renders with type parameters", () => {
+  const v1 = (
+    <function-declaration>
+      <ident name="test" />
+      <t:param>
+        <ident name="A" />
+      </t:param>
+      <t:param>
+        <ident name="B" />
+      </t:param>
+      <t:param>
+        <ident name="C" />
+      </t:param>
+      <param>
+        <ident name="a" />
+      </param>
+      <param>
+        <ident name="b" />
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </param>
+      <param>
+        <ident name="c" />
+        <t:ref>
+          <ident name="C" />
+        </t:ref>
+        <l:string value="hello" />
+      </param>
+      <block />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe('function test<A,B,C>(a,b:B,c:C="hello"){}');
+});
+
+test("function-declaration renders with type predicate", () => {
+  const v1 = (
+    <function-declaration>
+      <ident name="test" />
+      <t:param>
+        <ident name="A" />
+      </t:param>
+      <t:param>
+        <ident name="B" />
+      </t:param>
+      <t:param>
+        <ident name="C" />
+      </t:param>
+      <param>
+        <ident name="a" />
+      </param>
+      <param>
+        <ident name="b" />
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </param>
+      <param>
+        <ident name="c" />
+        <t:ref>
+          <ident name="C" />
+        </t:ref>
+        <l:string value="hello" />
+      </param>
+      <t:predicate>
+        <ident name="b" />
+        <t:primitive type="string" />
+      </t:predicate>
+      <block />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe(
+    'function test<A,B,C>(a,b:B,c:C="hello"):b is string{}'
+  );
+});
+
+test("function-declaration renders with generator token", () => {
+  const v1 = (
+    <function-declaration generator={true}>
+      <ident name="test" />
+      <block />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe("function* test(){}");
+});
+
+test("function-declaration renders with named export", () => {
+  const v1 = (
+    <function-declaration exported="named">
+      <ident name="test" />
+      <block />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe("export function test(){}");
+});
+
+test("function-declaration renders with default export", () => {
+  const v1 = (
+    <function-declaration exported="default">
+      <ident name="test" />
+      <block />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe("export default function test(){}");
+});
+
+test("function-declaration renders with default export and no name", () => {
+  const v1 = (
+    <function-declaration exported="default">
+      <block />
+    </function-declaration>
+  );
+
+  expect(v1.render()).toBe("export default function (){}");
+});
+
+test("function-declaration throws an error if no name is provided and it is not a default export", () => {
+  expect(() => (
+    <function-declaration exported="named">
+      <block />
+    </function-declaration>
+  )).toThrow();
+
+  expect(() => (
+    <function-declaration>
+      <block />
+    </function-declaration>
+  )).toThrow();
+});
+
+test("function-declaration throws an error if generator is specified without a body", () => {
+  expect(() => (
+    <function-declaration generator={true}>
+      <ident name="test" />
+    </function-declaration>
+  )).toThrow();
+});

--- a/jastx-test/tests/function-expression.test.tsx
+++ b/jastx-test/tests/function-expression.test.tsx
@@ -1,0 +1,141 @@
+import { expect, test } from "vitest";
+
+test("expr:function renders correctly", () => {
+  const v1 = (
+    <expr:function>
+      <ident name="test" />
+      <block />
+    </expr:function>
+  );
+
+  expect(v1.render()).toBe("function test(){}");
+});
+
+test("expr:function renders with parameters", () => {
+  const v1 = (
+    <expr:function>
+      <ident name="test" />
+      <param>
+        <ident name="a" />
+      </param>
+      <param>
+        <ident name="b" />
+        <t:primitive type="string" />
+      </param>
+      <param>
+        <ident name="c" />
+        <t:primitive type="string" />
+        <l:string value="hello" />
+      </param>
+      <block />
+    </expr:function>
+  );
+
+  expect(v1.render()).toBe('function test(a,b:string,c:string="hello"){}');
+});
+
+test("expr:function renders with type parameters", () => {
+  const v1 = (
+    <expr:function>
+      <ident name="test" />
+      <t:param>
+        <ident name="A" />
+      </t:param>
+      <t:param>
+        <ident name="B" />
+      </t:param>
+      <t:param>
+        <ident name="C" />
+      </t:param>
+      <param>
+        <ident name="a" />
+      </param>
+      <param>
+        <ident name="b" />
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </param>
+      <param>
+        <ident name="c" />
+        <t:ref>
+          <ident name="C" />
+        </t:ref>
+        <l:string value="hello" />
+      </param>
+      <block />
+    </expr:function>
+  );
+
+  expect(v1.render()).toBe('function test<A,B,C>(a,b:B,c:C="hello"){}');
+});
+
+test("expr:function renders with type predicate", () => {
+  const v1 = (
+    <expr:function>
+      <ident name="test" />
+      <t:param>
+        <ident name="A" />
+      </t:param>
+      <t:param>
+        <ident name="B" />
+      </t:param>
+      <t:param>
+        <ident name="C" />
+      </t:param>
+      <param>
+        <ident name="a" />
+      </param>
+      <param>
+        <ident name="b" />
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </param>
+      <param>
+        <ident name="c" />
+        <t:ref>
+          <ident name="C" />
+        </t:ref>
+        <l:string value="hello" />
+      </param>
+      <t:predicate>
+        <ident name="b" />
+        <t:primitive type="string" />
+      </t:predicate>
+      <block />
+    </expr:function>
+  );
+
+  expect(v1.render()).toBe(
+    'function test<A,B,C>(a,b:B,c:C="hello"):b is string{}'
+  );
+});
+
+test("expr:function renders with generator token", () => {
+  const v1 = (
+    <expr:function generator={true}>
+      <ident name="test" />
+      <block />
+    </expr:function>
+  );
+
+  expect(v1.render()).toBe("function* test(){}");
+});
+
+test("expr:function throws an error if no body is spoecified", () => {
+  expect(() => (
+    <expr:function>
+      <ident name="test" />
+    </expr:function>
+  )).toThrow();
+});
+
+test("expr:function throws an error if no other nodes are specifeid", () => {
+  expect(() => (
+    <expr:function generator={true}>
+      <ident name="test" />
+      <ident name="test2" />
+    </expr:function>
+  )).toThrow();
+});

--- a/jastx/src/builders/blocks.ts
+++ b/jastx/src/builders/blocks.ts
@@ -4,12 +4,13 @@ import {
   InvalidExportedMembersError,
 } from "../errors.js";
 import { AstNode, BLOCK_STATEMENTS_AND_DECLARATIONS } from "../types.js";
+import { isFunctionDeclaration } from "./function-declaration.js";
 import { isVariableStatement } from "./variable-statement.js";
 
 const type = "block";
 
 export interface BlockProps {
-  children: any;
+  children?: any;
 }
 
 export interface BlockNode extends AstNode {
@@ -33,7 +34,9 @@ export function createBlock(props: BlockProps): BlockNode {
   }
 
   const modified_statements = statements.filter(
-    (a) => isVariableStatement(a) && a.props.exported
+    (a) =>
+      (isVariableStatement(a) && a.props.exported) ||
+      (isFunctionDeclaration(a) && a.props.exported)
   );
 
   if (modified_statements.length > 0) {
@@ -43,6 +46,9 @@ export function createBlock(props: BlockProps): BlockNode {
   return {
     type: type,
     props,
-    render: () => `{${statements.map((a) => a.render()).join(";")};}`,
+    render: () =>
+      `{${statements.map((a) => a.render()).join(";")}${
+        statements.length > 0 ? ";" : ""
+      }}`,
   };
 }

--- a/jastx/src/builders/function-declaration.ts
+++ b/jastx/src/builders/function-declaration.ts
@@ -1,0 +1,99 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidSyntaxError } from "../errors.js";
+import { AstNode, TYPE_TYPES } from "../types.js";
+
+const type = "function-declaration";
+
+export interface FunctionDeclarationProps {
+  children: any;
+  /**
+   * Generator is only useable when a function body is provided,
+   * it will throw an error if provided without a body
+   */
+  generator?: boolean;
+  /**
+   * Non-default exports require a name, whereas default exports
+   * do not. We need to specify this here.
+   */
+  exported?: "named" | "default";
+}
+
+export interface FunctionDeclarationNode extends AstNode {
+  type: typeof type;
+  props: FunctionDeclarationProps;
+}
+
+export function isFunctionDeclaration(
+  node: AstNode
+): node is FunctionDeclarationNode {
+  return node.type === type;
+}
+
+export function createFunctionDeclaration(
+  props: FunctionDeclarationProps
+): FunctionDeclarationNode {
+  const walker = createChildWalker(type, props);
+  const export_type = props.exported ?? "none";
+
+  const ident =
+    // Default exports do not require a name
+    props.exported === "default"
+      ? walker.spliceAssertNextOptional("ident")
+      : walker.spliceAssertNext("ident");
+
+  const parameters = walker.spliceAssertGroup("param");
+  const type_parameters = walker.spliceAssertGroup("t:param");
+
+  let type_node = walker.spliceAssertNextOptional([
+    ...TYPE_TYPES,
+    "t:predicate",
+  ]);
+
+  const render_parameters = () => {
+    if (type_parameters.length > 0) {
+      return `<${type_parameters.map((a) => a.render()).join(",")}>(${parameters
+        .map((a) => a.render())
+        .join(",")})`;
+    }
+
+    return `(${parameters.map((a) => a.render()).join(",")})`;
+  };
+
+  const block = walker.spliceAssertNextOptional("block");
+
+  if (!block && props.generator) {
+    throw new InvalidSyntaxError(
+      `<${type}> cannot declare a generator function without a body. A body can be ommitted in the case that this is an overload declaration, but an overload declaration does not specify the generator syntax`
+    );
+  }
+
+  if (walker.remainingChildren.length > 0) {
+    if (block) {
+      throw new InvalidSyntaxError(
+        `<${type}> must only specify a <block>. Found a <block> and then another value:\n- ${walker.remainingChildren[0].render()}`
+      );
+    } else {
+      throw new InvalidSyntaxError(
+        `<${type}> can only specify a <block> as the body. This can be ommitted completely for overloads, but no other type can be used`
+      );
+    }
+  }
+
+  const render_export_modifiers = () =>
+    export_type === "default"
+      ? "export default "
+      : export_type === "named"
+      ? "export "
+      : "";
+
+  return {
+    type,
+    props,
+    render: () =>
+      `${render_export_modifiers()}function${props.generator ? "*" : ""} ${
+        ident ? ident.render() : ""
+      }${render_parameters()}${type_node ? `:${type_node.render()}` : ""}${
+        block ? block.render() : ""
+      }`,
+  };
+}

--- a/jastx/src/builders/function-expression.ts
+++ b/jastx/src/builders/function-expression.ts
@@ -1,0 +1,77 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidSyntaxError } from "../errors.js";
+import { AstNode, TYPE_TYPES } from "../types.js";
+
+const type = "expr:function";
+
+export interface FunctionExpressionProps {
+  children: any;
+  /**
+   * Generator is only useable when a function body is provided,
+   * it will throw an error if provided without a body
+   */
+  generator?: boolean;
+}
+
+export interface FunctionExpressionNode extends AstNode {
+  type: typeof type;
+  props: FunctionExpressionProps;
+}
+
+export function isFunctionExpression(
+  node: AstNode
+): node is FunctionExpressionNode {
+  return node.type === type;
+}
+
+export function FunctionExpressionHasBody(node: FunctionExpressionNode) {
+  const children = node.props.children ?? [];
+  const child_array = Array.isArray(children) ? children : [children];
+
+  return child_array.some((a) => typeof a !== "string" && a.type === "block");
+}
+
+export function createFunctionExpression(
+  props: FunctionExpressionProps
+): FunctionExpressionNode {
+  const walker = createChildWalker(type, props);
+
+  const ident = walker.spliceAssertNextOptional("ident");
+
+  const parameters = walker.spliceAssertGroup("param");
+  const type_parameters = walker.spliceAssertGroup("t:param");
+
+  let type_node = walker.spliceAssertNextOptional([
+    ...TYPE_TYPES,
+    "t:predicate",
+  ]);
+
+  const render_parameters = () => {
+    if (type_parameters.length > 0) {
+      return `<${type_parameters.map((a) => a.render()).join(",")}>(${parameters
+        .map((a) => a.render())
+        .join(",")})`;
+    }
+
+    return `(${parameters.map((a) => a.render()).join(",")})`;
+  };
+
+  const block = walker.spliceAssertNext("block");
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidSyntaxError(
+      `<${type}> must only specify a <block>. Found a <block> and then another value:\n- ${walker.remainingChildren[0].render()}`
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () =>
+      `function${props.generator ? "*" : ""} ${
+        ident ? ident.render() : ""
+      }${render_parameters()}${type_node ? `:${type_node.render()}` : ""}${
+        block ? block.render() : ""
+      }`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -29,6 +29,15 @@ import {
   createExactLiteral,
   ExactLiteralProps,
 } from "./builders/exact-literal.js";
+import {
+  createFunctionDeclaration,
+  FunctionDeclarationProps,
+} from "./builders/function-declaration.js";
+import {
+  createFunctionExpression,
+  FunctionExpressionNode,
+  FunctionExpressionProps,
+} from "./builders/function-expression.js";
 import { createIdentifier, IdentifierProps } from "./builders/identifier.js";
 import {
   ArrayLiteralProps,
@@ -140,6 +149,8 @@ export const jsxs = <T>(
         return createParameter(options as ParameterProps);
       case "arrow-function":
         return createArrowFunction(options as ArrowFunctionProps);
+      case "function-declaration":
+        return createFunctionDeclaration(options as FunctionDeclarationProps);
 
       case "exact-literal":
         return createExactLiteral(options as ExactLiteralProps);
@@ -197,6 +208,9 @@ export const jsxs = <T>(
         return createTemplateExpression(options as TemplateExpressionlProps);
       case "expr:call":
         return createCallExpression(options as CallExpressionProps);
+      case "expr:function":
+        return createFunctionExpression(options as FunctionExpressionProps);
+
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
       case "bind:array-elem":
@@ -270,6 +284,7 @@ declare global {
       ["block"]: BlockProps;
       ["param"]: ParameterProps;
       ["arrow-function"]: ArrowFunctionProps;
+      ["function-declaration"]: FunctionDeclarationProps;
 
       ["exact-literal"]: ExactLiteralProps;
       ["var:declaration"]: VariableDeclarationProps;
@@ -282,6 +297,7 @@ declare global {
       ["expr:elem-access"]: ElementAccessExpressionProps;
       ["expr:template"]: TemplateExpressionlProps;
       ["expr:call"]: CallExpressionProps;
+      ["expr:function"]: FunctionExpressionProps;
 
       ["bind:array"]: ArrayBindingProps;
       ["bind:object"]: ObjectBindingProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -41,6 +41,7 @@ const _expressions = [
   "elem-access",
   "template",
   "call",
+  "function",
 ] as const;
 
 export type ExpressionTypeName = (typeof _expressions)[number];
@@ -63,6 +64,7 @@ export type ElementType =
   | "text"
   | "block"
   | "arrow-function"
+  | "function-declaration"
   | "param"
   | "var:statement"
   | "var:declaration"
@@ -88,6 +90,7 @@ export const EXPRESSION_TYPES: readonly ExpressionType[] = [
   "expr:elem-access",
   "expr:template",
   "expr:call",
+  "expr:function",
 ];
 
 export const LITERAL_PRIMITIVE_TYPES: readonly LiteralElementType[] = [
@@ -121,6 +124,7 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
 
 export const BLOCK_STATEMENTS_AND_DECLARATIONS: readonly ElementType[] = [
   "var:statement",
+  "function-declaration",
 ];
 
 export function isTypeType(v: string) {


### PR DESCRIPTION
Adds function expressions and declarations. They look very similar, but they're used in slightly different contexts and have a few different rules governing them.

They both basically follow the same general look which is
```typescript
function doSomething () {
   ...
}
```

The type parameters, parameters, and return types all function the same, but there are differences in the other components.

Firstly, they belong in different places. A function expression is a "value" so a variable is assigned a function expression as it's value. A declaration is a block level statement that is written directly into the block without any assignment

Expression style
```typescript
const a = function test () {
   ...
}
```

Declaration style
```typescript
function test () {
  ...
}
```

As such, a function expression does not require an identifier, it can be created as an anonymous function pretty easily:
```typescript
const a = function () {
  ...
}

doAThing(function () { ... });
```

A function declaration on the other hand always (almost always) requires an identifier 
```typescript
// This makes no sense by itself, how would you call it?
function () {
  ...
}
```

A function declaration, being a statement, can be exported

```typescript
export function test () {
  ...
}

export default function test () {
  ...
}
```

And here is the exception to the naming rule: If a function declaration is exported by default at the top level, it does not require a name:
```typescript
export default function () {
  ...
}
```

Both types can be specified as generator functions
```html
<function-declaration generator={true}>
 ...
</function-declaration>
<expr:function generator={true}>
  ...
</expr:function>
```

This basically adds an asterisk to the function keyword for both

```typescript
function* someGeneratorFunction () {
  ...
}
```

## Hazy details surrounding function declarations

On top of what I've mentioned above, there are some other uses for function declarations which make the syntax kind of ambiguous. 

For starters, a function declaration can have overloads

```typescript
function test (a: string, b: number);
function test (a: number);
function test (a: string | number, b?: number) {
  ...
}
```

Typescript declares each of these as just individual function declarations, some with a body, some without. So if we follow along with Typescript's AST model, we would need to compare siblings to check identifiers and ensure that a function declaration without a body was followed by another function declaration with a body, and with the same identifier. This is kind of tricky because we're really only rendering elements in isolation, and walking up the tree. This would possibly require a second pass, or some complicated digging in to the AST nodes to figure out.

On top of that, if the function is an overload, then the generate syntax can't be applied to it
```typescript
// Invalid, only the actual function with a body should have the generator token
function* test (a: string, b: number);
function* test (a: number);
function* test (a: string | number, b?: number) {
  ...
}

// Correct
function test (a: string, b: number);
function test (a: number);
function* test (a: string | number, b?: number) {
  ...
}
```

The second problem is ambient declarations. There we have this syntax
```typescript
declare function a ();
```

Typescript models this in the AST as a function declaration as well. But with a declare modifier. Different rules again apply here. The function cannot have the generator token, and the function cannot have a body at all. 
