### PR TITLE
Add if/else statement syntax

### DIFF
--- a/jastx-test/tests/if-statement.test.tsx
+++ b/jastx-test/tests/if-statement.test.tsx
@@ -1,0 +1,130 @@
+import { expect, test } from "vitest";
+
+test("if-statement renders correctly with a single expression", () => {
+  const v = (
+    <if-statement>
+      <ident name="v" />
+      <expr:statement>
+        <expr:call>
+          <ident name="v" />
+        </expr:call>
+      </expr:statement>
+    </if-statement>
+  );
+
+  expect(v.render()).toBe("if(v)v()");
+});
+
+test("if-statement renders correctly with a block", () => {
+  const v = (
+    <if-statement>
+      <ident name="v" />
+      <block>
+        <expr:statement>
+          <expr:call>
+            <ident name="v" />
+          </expr:call>
+        </expr:statement>
+      </block>
+    </if-statement>
+  );
+
+  expect(v.render()).toBe("if(v){v();}");
+});
+
+test("if-statement renders correctly with an else single statement", () => {
+  const v = (
+    <if-statement>
+      <ident name="v" />
+      <expr:statement>
+        <expr:call>
+          <ident name="v" />
+        </expr:call>
+      </expr:statement>
+      <expr:statement>
+        <expr:call>
+          <ident name="x" />
+        </expr:call>
+      </expr:statement>
+    </if-statement>
+  );
+
+  expect(v.render()).toBe("if(v)v();else x()");
+});
+
+test("if-statement renders correctly with an else block", () => {
+  const v = (
+    <if-statement>
+      <ident name="v" />
+      <expr:statement>
+        <expr:call>
+          <ident name="v" />
+        </expr:call>
+      </expr:statement>
+      <block>
+        <expr:statement>
+          <expr:call>
+            <ident name="x" />
+          </expr:call>
+        </expr:statement>
+      </block>
+    </if-statement>
+  );
+
+  expect(v.render()).toBe("if(v)v();else{x();}");
+  const v2 = (
+    <if-statement>
+      <ident name="v" />
+      <block>
+        <expr:statement>
+          <expr:call>
+            <ident name="v" />
+          </expr:call>
+        </expr:statement>
+      </block>
+      <block>
+        <expr:statement>
+          <expr:call>
+            <ident name="x" />
+          </expr:call>
+        </expr:statement>
+      </block>
+    </if-statement>
+  );
+
+  expect(v2.render()).toBe("if(v){v();}else{x();}");
+});
+
+test("if-statement renders correctly with nested if statements", () => {
+  const v = (
+    <if-statement>
+      <ident name="v" />
+      <block>
+        <expr:statement>
+          <expr:call>
+            <ident name="x" />
+          </expr:call>
+        </expr:statement>
+      </block>
+      <if-statement>
+        <ident name="a" />
+        <block>
+          <expr:statement>
+            <expr:call>
+              <ident name="a" />
+            </expr:call>
+          </expr:statement>
+        </block>
+        <block>
+          <expr:statement>
+            <expr:call>
+              <ident name="v" />
+            </expr:call>
+          </expr:statement>
+        </block>
+      </if-statement>
+    </if-statement>
+  );
+
+  expect(v.render()).toBe("if(v){x();}else if(a){a();}else{v();}");
+});

--- a/jastx/src/builders/expression-statement.ts
+++ b/jastx/src/builders/expression-statement.ts
@@ -1,0 +1,43 @@
+import { assertNChildren } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { AmbiguousParserError } from "../errors.js";
+import { AstNode, EXPRESSION_OR_LITERAL_TYPES } from "../types.js";
+
+const type = "expr:statement";
+
+export interface ExpressionStatementProps {
+  children: any;
+}
+
+export interface ExpressionStatementNode extends AstNode {
+  type: typeof type;
+  props: ExpressionStatementProps;
+}
+
+export function createExpressionStatement(
+  props: ExpressionStatementProps
+): ExpressionStatementNode {
+  assertNChildren(type, 1, props);
+
+  const walker = createChildWalker(type, props);
+
+  // as-expression can't use value types because it can't directly use an arrow-function
+  // () => { return void 0; } as unknown as invalid syntax, it needs to be
+  // (() => { return void 0; }) as unknown
+  const expr_node = walker.spliceAssertNext([
+    ...EXPRESSION_OR_LITERAL_TYPES,
+    "ident",
+  ]);
+
+  if (expr_node.type === "expr:function") {
+    throw new AmbiguousParserError(
+      `<${type}> can not have an <expr:function> expression inside, because the code produced would be amibguos and ultimately resolved as a function declaration instead. You can just use a function declaration directly here.`
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: expr_node.render,
+  };
+}

--- a/jastx/src/builders/if-statement.ts
+++ b/jastx/src/builders/if-statement.ts
@@ -1,0 +1,60 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import {
+  AstNode,
+  BLOCK_STATEMENTS_AND_DECLARATIONS,
+  ElementType,
+  EXPRESSION_OR_LITERAL_TYPES,
+  omitFrom,
+} from "../types.js";
+
+const type = "if-statement";
+
+export interface IfStatementProps {
+  children: any;
+}
+
+export interface IfStatementNode extends AstNode {
+  type: typeof type;
+  props: IfStatementProps;
+}
+
+const allowed_body = [
+  ...omitFrom(BLOCK_STATEMENTS_AND_DECLARATIONS, "var:statement"),
+  "block",
+] as ElementType[];
+
+export function createIfStatement(props: IfStatementProps): IfStatementNode {
+  const walker = createChildWalker(type, props);
+
+  const condition_node = walker.spliceAssertNext([
+    ...EXPRESSION_OR_LITERAL_TYPES,
+    "ident",
+  ]);
+
+  const body_node = walker.spliceAssertNext(allowed_body);
+  const else_node = walker.spliceAssertNextOptional(allowed_body);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      allowed_body,
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () =>
+      `if(${condition_node.render()})${body_node.render()}${
+        body_node.type !== "block" && else_node ? ";" : ""
+      }${
+        else_node
+          ? else_node.type === "block"
+            ? `else${else_node.render()}`
+            : `else ${else_node.render()}`
+          : ""
+      }`,
+  };
+}

--- a/jastx/src/errors.ts
+++ b/jastx/src/errors.ts
@@ -51,3 +51,5 @@ export class InvalidExportedMembersError extends InvalidSyntaxError {
     );
   }
 }
+
+export class AmbiguousParserError extends Error {}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -30,15 +30,22 @@ import {
   ExactLiteralProps,
 } from "./builders/exact-literal.js";
 import {
+  createExpressionStatement,
+  ExpressionStatementProps,
+} from "./builders/expression-statement.js";
+import {
   createFunctionDeclaration,
   FunctionDeclarationProps,
 } from "./builders/function-declaration.js";
 import {
   createFunctionExpression,
-  FunctionExpressionNode,
   FunctionExpressionProps,
 } from "./builders/function-expression.js";
 import { createIdentifier, IdentifierProps } from "./builders/identifier.js";
+import {
+  createIfStatement,
+  IfStatementProps,
+} from "./builders/if-statement.js";
 import {
   ArrayLiteralProps,
   BigintLiteralProps,
@@ -151,6 +158,8 @@ export const jsxs = <T>(
         return createArrowFunction(options as ArrowFunctionProps);
       case "function-declaration":
         return createFunctionDeclaration(options as FunctionDeclarationProps);
+      case "if-statement":
+        return createIfStatement(options as IfStatementProps);
 
       case "exact-literal":
         return createExactLiteral(options as ExactLiteralProps);
@@ -210,6 +219,8 @@ export const jsxs = <T>(
         return createCallExpression(options as CallExpressionProps);
       case "expr:function":
         return createFunctionExpression(options as FunctionExpressionProps);
+      case "expr:statement":
+        return createExpressionStatement(options as ExpressionStatementProps);
 
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
@@ -285,6 +296,7 @@ declare global {
       ["param"]: ParameterProps;
       ["arrow-function"]: ArrowFunctionProps;
       ["function-declaration"]: FunctionDeclarationProps;
+      ["if-statement"]: IfStatementProps;
 
       ["exact-literal"]: ExactLiteralProps;
       ["var:declaration"]: VariableDeclarationProps;
@@ -298,6 +310,7 @@ declare global {
       ["expr:template"]: TemplateExpressionlProps;
       ["expr:call"]: CallExpressionProps;
       ["expr:function"]: FunctionExpressionProps;
+      ["expr:statement"]: ExpressionStatementProps;
 
       ["bind:array"]: ArrayBindingProps;
       ["bind:object"]: ObjectBindingProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -42,6 +42,7 @@ const _expressions = [
   "template",
   "call",
   "function",
+  "statement",
 ] as const;
 
 export type ExpressionTypeName = (typeof _expressions)[number];
@@ -65,6 +66,7 @@ export type ElementType =
   | "block"
   | "arrow-function"
   | "function-declaration"
+  | "if-statement"
   | "param"
   | "var:statement"
   | "var:declaration"
@@ -125,7 +127,17 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
 export const BLOCK_STATEMENTS_AND_DECLARATIONS: readonly ElementType[] = [
   "var:statement",
   "function-declaration",
+  "if-statement",
+  "expr:statement",
 ];
+
+export function omitFrom(
+  t: ElementType[] | readonly ElementType[],
+  types: ElementType | ElementType[]
+) {
+  const omit_types = Array.isArray(types) ? types : [types];
+  return t.filter((v) => !omit_types.includes(v));
+}
 
 export function isTypeType(v: string) {
   return TYPE_TYPES.includes(v as TypeElementType);


### PR DESCRIPTION
Adds the if/else statement syntax. It's kind of unnatural at first glance because you'd expect if/else if/else to all be serperate syntax's. But they're actually just nested versions of each other

A single if statement generally folows the format
```
- if 
  - condition
  - body
```

To make it an if/else statement, then you just attach a single body element
```
- if
  - condition
  - if body
  - else body
```

An else if statement is just an if statement used as the body of an else statement, which kind of makes sense when you think about it
```
- if
  - condition
  - if body
  - if
    - condition
    - if body
    - else body
```

That will generate approximately
```typescript
if (condition) {
  // body
}
else if (condition) {
  // body
}
else {
  // body
}
```

