### PR TITLE
Adds various unary expressions

### DIFF
--- a/jastx-test/tests/unary-expression.test.tsx
+++ b/jastx-test/tests/unary-expression.test.tsx
@@ -66,4 +66,39 @@ test("expr:await renders parenthesis where required", () => {
   );
 
   expect(v.render()).toBe("await (()=>x)");
+  const v2 = (
+    <expr:await>
+      <expr:yield_>
+        <arrow-function>
+          <ident name="x" />
+        </arrow-function>
+      </expr:yield_>
+    </expr:await>
+  );
+
+  expect(v2.render()).toBe("await (yield (()=>x))");
+});
+
+test("expr:typeof renders correctly", () => {
+  const v = (
+    <expr:typeof>
+      <expr:call>
+        <ident name="x" />
+      </expr:call>
+    </expr:typeof>
+  );
+
+  expect(v.render()).toBe("typeof x()");
+});
+
+test("expr:typeof renders parenthesis where required", () => {
+  const v = (
+    <expr:typeof>
+      <arrow-function>
+        <ident name="x" />
+      </arrow-function>
+    </expr:typeof>
+  );
+
+  expect(v.render()).toBe("typeof (()=>x)");
 });

--- a/jastx-test/tests/unary-expression.test.tsx
+++ b/jastx-test/tests/unary-expression.test.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+
+test("expr:not renders correctly", () => {
+  const v = (
+    <expr:not>
+      <ident name="x" />
+    </expr:not>
+  );
+
+  expect(v.render()).toBe("!x");
+});
+
+test("expr:not renders double negation when nested", () => {
+  const v = (
+    <expr:not>
+      <expr:not>
+        <ident name="x" />
+      </expr:not>
+    </expr:not>
+  );
+
+  expect(v.render()).toBe("!!x");
+});
+
+test("expr:not renders arrow-function expression in parenthesis", () => {
+  const v = (
+    <expr:not>
+      <arrow-function>
+        <block />
+      </arrow-function>
+    </expr:not>
+  );
+
+  expect(v.render()).toBe("!(()=>{})");
+});

--- a/jastx-test/tests/unary-expression.test.tsx
+++ b/jastx-test/tests/unary-expression.test.tsx
@@ -33,3 +33,27 @@ test("expr:not renders arrow-function expression in parenthesis", () => {
 
   expect(v.render()).toBe("!(()=>{})");
 });
+
+test("expr:await renders correctly", () => {
+  const v = (
+    <expr:await>
+      <expr:call>
+        <ident name="x" />
+      </expr:call>
+    </expr:await>
+  );
+
+  expect(v.render()).toBe("await x()");
+});
+
+test("expr:await renders parenthesis where required", () => {
+  const v = (
+    <expr:await>
+      <arrow-function>
+        <ident name="x" />
+      </arrow-function>
+    </expr:await>
+  );
+
+  expect(v.render()).toBe("await (()=>x)");
+});

--- a/jastx-test/tests/unary-expression.test.tsx
+++ b/jastx-test/tests/unary-expression.test.tsx
@@ -22,6 +22,16 @@ test("expr:not renders double negation when nested", () => {
   expect(v.render()).toBe("!!x");
 });
 
+test("expr:not renders shorthand dobule negation", () => {
+  const v = (
+    <expr:not double={true}>
+      <ident name="x" />
+    </expr:not>
+  );
+
+  expect(v.render()).toBe("!!x");
+});
+
 test("expr:not renders arrow-function expression in parenthesis", () => {
   const v = (
     <expr:not>

--- a/jastx/src/builders/as-expression.ts
+++ b/jastx/src/builders/as-expression.ts
@@ -27,13 +27,17 @@ export function createAsExpression(props: AsExpressionProps): AsExpressionNode {
     "ident",
   ]);
 
+  const requires_parens = expr_node.type === "arrow-function";
+
   const type_node = walker.spliceAssertNext([...TYPE_TYPES]);
 
   return {
     type,
     props,
     render: () => {
-      return `${expr_node.render()} as ${type_node.render()}`;
+      return `${
+        requires_parens ? `(${expr_node.render()})` : expr_node.render()
+      } as ${type_node.render()}`;
     },
   };
 }

--- a/jastx/src/builders/element-access-expression.ts
+++ b/jastx/src/builders/element-access-expression.ts
@@ -1,6 +1,11 @@
 import { assertNChildren } from "../asserts.js";
 import { LhsInvalidTypeError } from "../errors.js";
-import { AstNode, EXPRESSION_TYPES, LITERAL_TYPES } from "../types.js";
+import {
+  AstNode,
+  EXPRESSION_OR_LITERAL_TYPES,
+  isBinaryExpressionType,
+  isUnaryExpressionType,
+} from "../types.js";
 
 const type = "expr:elem-access";
 
@@ -14,8 +19,8 @@ export interface ElementAccessExpressionNode extends AstNode {
   props: ElementAccessExpressionProps;
 }
 
-const lhs_types = [...EXPRESSION_TYPES, ...LITERAL_TYPES, "ident"];
-const rhs_types = [...EXPRESSION_TYPES, ...LITERAL_TYPES, "ident"];
+const lhs_types = [...EXPRESSION_OR_LITERAL_TYPES, "ident"];
+const rhs_types = [...EXPRESSION_OR_LITERAL_TYPES, "ident"];
 
 export function createElementAccessExpression(
   props: ElementAccessExpressionProps
@@ -32,10 +37,15 @@ export function createElementAccessExpression(
     throw new LhsInvalidTypeError(type, rhs_types, rhs.type);
   }
 
+  const requires_parens =
+    isUnaryExpressionType(lhs.type) || isBinaryExpressionType(lhs.type);
+
   return {
     type,
     props,
     render: () =>
-      `${lhs.render()}${props.optionalChain ? "?." : ""}[${rhs.render()}]`,
+      `${requires_parens ? `(${lhs.render()})` : lhs.render()}${
+        props.optionalChain ? "?." : ""
+      }[${rhs.render()}]`,
   };
 }

--- a/jastx/src/builders/non-null-expression.ts
+++ b/jastx/src/builders/non-null-expression.ts
@@ -1,5 +1,6 @@
+import { assertNChildren } from "../asserts.js";
 import { createChildWalker } from "../child-walker.js";
-import { AstNode, LITERAL_TYPES } from "../types.js";
+import { AstNode, VALUE_TYPES } from "../types.js";
 
 const type = "expr:non-null";
 
@@ -16,18 +17,16 @@ export interface NonNullExpressionNode extends AstNode {
 export function createNonNullExpression(
   props: NonNullExpressionProps
 ): NonNullExpressionNode {
+  assertNChildren(type, 1, props);
   const walker = createChildWalker(type, props);
 
-  const expr_node = walker.spliceAssertOneof(
-    [...LITERAL_TYPES, "expr:parens", "ident"],
-    1
-  );
+  const expr_node = walker.spliceAssertNext([...VALUE_TYPES]);
+  const requires_parens = ["arrow-function"].includes(expr_node.type);
 
   return {
     type,
     props,
-    render: () => {
-      return `${expr_node.render()}!`;
-    },
+    render: () =>
+      `${requires_parens ? `(${expr_node.render()})` : expr_node.render()}!`,
   };
 }

--- a/jastx/src/builders/property-access-expression.ts
+++ b/jastx/src/builders/property-access-expression.ts
@@ -1,6 +1,12 @@
 import { assertNChildren } from "../asserts.js";
 import { InvalidSyntaxError } from "../errors.js";
-import { AstNode, EXPRESSION_TYPES } from "../types.js";
+import {
+  AstNode,
+  EXPRESSION_OR_LITERAL_TYPES,
+  isBinaryExpressionType,
+  isUnaryExpressionType,
+  omitFrom,
+} from "../types.js";
 
 const type = "expr:prop-access";
 
@@ -28,7 +34,10 @@ export function createPropertyAccessExpression(
     );
   }
 
-  const lhs_types = [...EXPRESSION_TYPES, "ident", "l:string", "l:boolean"];
+  const lhs_types = omitFrom(
+    [...EXPRESSION_OR_LITERAL_TYPES, "ident"],
+    "l:number"
+  );
 
   if (!lhs_types.includes(lhs.type)) {
     throw new InvalidSyntaxError(
@@ -38,10 +47,15 @@ export function createPropertyAccessExpression(
     );
   }
 
+  const requires_parens =
+    isBinaryExpressionType(lhs.type) || isUnaryExpressionType(lhs.type);
+
   return {
     type,
     props,
     render: () =>
-      `${lhs.render()}${props.optionalChain ? "?" : ""}.${rhs.render()}`,
+      `${requires_parens ? `(${lhs.render()})` : lhs.render()}${
+        props.optionalChain ? "?" : ""
+      }.${rhs.render()}`,
   };
 }

--- a/jastx/src/builders/unary-expression.ts
+++ b/jastx/src/builders/unary-expression.ts
@@ -2,6 +2,8 @@ import { assertNChildren } from "../asserts.js";
 import { createChildWalker } from "../child-walker.js";
 import { AstNode, VALUE_TYPES } from "../types.js";
 
+const requires_parens_types = ["arrow-function", "expr:yield_"];
+
 const not_type = "expr:not";
 export interface NotExpressionProps {
   children: any;
@@ -21,7 +23,7 @@ export function createNotExpression(
 
   const walker = createChildWalker(not_type, props);
   const expression = walker.spliceAssertNext([...VALUE_TYPES]);
-  const requires_parens = ["arrow-function"].includes(expression.type);
+  const requires_parens = requires_parens_types.includes(expression.type);
 
   return {
     type: not_type,
@@ -50,13 +52,71 @@ export function createAwaitExpression(
 
   const walker = createChildWalker(await_type, props);
   const expression = walker.spliceAssertNext([...VALUE_TYPES]);
-  const requires_parens = ["arrow-function"].includes(expression.type);
+  const requires_parens = requires_parens_types.includes(expression.type);
 
   return {
     type: await_type,
     props,
     render: () =>
       `await ${
+        requires_parens ? `(${expression.render()})` : expression.render()
+      }`,
+  };
+}
+
+const typeof_type = "expr:typeof";
+export interface TypeofExpressionProps {
+  children: any;
+}
+
+export interface TypeofExpressionNode extends AstNode {
+  type: typeof typeof_type;
+  props: TypeofExpressionProps;
+}
+
+export function createTypeofExpression(
+  props: TypeofExpressionProps
+): TypeofExpressionNode {
+  assertNChildren(typeof_type, 1, props);
+
+  const walker = createChildWalker(typeof_type, props);
+  const expression = walker.spliceAssertNext([...VALUE_TYPES]);
+  const requires_parens = requires_parens_types.includes(expression.type);
+
+  return {
+    type: typeof_type,
+    props,
+    render: () =>
+      `typeof ${
+        requires_parens ? `(${expression.render()})` : expression.render()
+      }`,
+  };
+}
+
+const yield_type = "expr:yield_";
+export interface YieldExpressionProps {
+  children: any;
+}
+
+export interface YieldExpressionNode extends AstNode {
+  type: typeof yield_type;
+  props: YieldExpressionProps;
+}
+
+export function createYieldExpression(
+  props: YieldExpressionProps
+): YieldExpressionNode {
+  assertNChildren(yield_type, 1, props);
+
+  const walker = createChildWalker(yield_type, props);
+  const expression = walker.spliceAssertNext([...VALUE_TYPES]);
+  const requires_parens = requires_parens_types.includes(expression.type);
+
+  return {
+    type: yield_type,
+    props,
+    render: () =>
+      `yield ${
         requires_parens ? `(${expression.render()})` : expression.render()
       }`,
   };

--- a/jastx/src/builders/unary-expression.ts
+++ b/jastx/src/builders/unary-expression.ts
@@ -1,0 +1,31 @@
+import { assertNChildren } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { AstNode, VALUE_TYPES } from "../types.js";
+
+const type = "expr:not";
+
+export interface NotExpressionProps {
+  children: any;
+}
+
+export interface NotExpressionNode extends AstNode {
+  type: typeof type;
+  props: NotExpressionProps;
+}
+
+export function createNotExpression(
+  props: NotExpressionProps
+): NotExpressionNode {
+  assertNChildren(type, 1, props);
+
+  const walker = createChildWalker(type, props);
+  const expression = walker.spliceAssertNext([...VALUE_TYPES]);
+  const requires_parens = ["arrow-function"].includes(expression.type);
+
+  return {
+    type,
+    props,
+    render: () =>
+      `!${requires_parens ? `(${expression.render()})` : expression.render()}`,
+  };
+}

--- a/jastx/src/builders/unary-expression.ts
+++ b/jastx/src/builders/unary-expression.ts
@@ -5,6 +5,7 @@ import { AstNode, VALUE_TYPES } from "../types.js";
 const not_type = "expr:not";
 export interface NotExpressionProps {
   children: any;
+  double?: boolean;
 }
 
 export interface NotExpressionNode extends AstNode {
@@ -16,6 +17,7 @@ export function createNotExpression(
   props: NotExpressionProps
 ): NotExpressionNode {
   assertNChildren(not_type, 1, props);
+  const double = props.double || false;
 
   const walker = createChildWalker(not_type, props);
   const expression = walker.spliceAssertNext([...VALUE_TYPES]);
@@ -25,7 +27,9 @@ export function createNotExpression(
     type: not_type,
     props,
     render: () =>
-      `!${requires_parens ? `(${expression.render()})` : expression.render()}`,
+      `${double ? "!!" : "!"}${
+        requires_parens ? `(${expression.render()})` : expression.render()
+      }`,
   };
 }
 

--- a/jastx/src/builders/unary-expression.ts
+++ b/jastx/src/builders/unary-expression.ts
@@ -2,30 +2,58 @@ import { assertNChildren } from "../asserts.js";
 import { createChildWalker } from "../child-walker.js";
 import { AstNode, VALUE_TYPES } from "../types.js";
 
-const type = "expr:not";
-
+const not_type = "expr:not";
 export interface NotExpressionProps {
   children: any;
 }
 
 export interface NotExpressionNode extends AstNode {
-  type: typeof type;
+  type: typeof not_type;
   props: NotExpressionProps;
 }
 
 export function createNotExpression(
   props: NotExpressionProps
 ): NotExpressionNode {
-  assertNChildren(type, 1, props);
+  assertNChildren(not_type, 1, props);
 
-  const walker = createChildWalker(type, props);
+  const walker = createChildWalker(not_type, props);
   const expression = walker.spliceAssertNext([...VALUE_TYPES]);
   const requires_parens = ["arrow-function"].includes(expression.type);
 
   return {
-    type,
+    type: not_type,
     props,
     render: () =>
       `!${requires_parens ? `(${expression.render()})` : expression.render()}`,
+  };
+}
+
+const await_type = "expr:await";
+export interface AwaitExpressionProps {
+  children: any;
+}
+
+export interface AwaitExpressionNode extends AstNode {
+  type: typeof await_type;
+  props: AwaitExpressionProps;
+}
+
+export function createAwaitExpression(
+  props: AwaitExpressionProps
+): AwaitExpressionNode {
+  assertNChildren(await_type, 1, props);
+
+  const walker = createChildWalker(await_type, props);
+  const expression = walker.spliceAssertNext([...VALUE_TYPES]);
+  const requires_parens = ["arrow-function"].includes(expression.type);
+
+  return {
+    type: await_type,
+    props,
+    render: () =>
+      `await ${
+        requires_parens ? `(${expression.render()})` : expression.render()
+      }`,
   };
 }

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -112,6 +112,8 @@ import {
   TypeReferenceProps,
 } from "./builders/type-reference.js";
 import {
+  AwaitExpressionProps,
+  createAwaitExpression,
   createNotExpression,
   NotExpressionProps,
 } from "./builders/unary-expression.js";
@@ -227,6 +229,8 @@ export const jsxs = <T>(
         return createExpressionStatement(options as ExpressionStatementProps);
       case "expr:not":
         return createNotExpression(options as NotExpressionProps);
+      case "expr:await":
+        return createAwaitExpression(options as AwaitExpressionProps);
 
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
@@ -318,6 +322,7 @@ declare global {
       ["expr:function"]: FunctionExpressionProps;
       ["expr:statement"]: ExpressionStatementProps;
       ["expr:not"]: NotExpressionProps;
+      ["expr:await"]: AwaitExpressionProps;
 
       ["bind:array"]: ArrayBindingProps;
       ["bind:object"]: ObjectBindingProps;

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -112,6 +112,10 @@ import {
   TypeReferenceProps,
 } from "./builders/type-reference.js";
 import {
+  createNotExpression,
+  NotExpressionProps,
+} from "./builders/unary-expression.js";
+import {
   createVariableDeclarationList,
   VariableDeclarationListProps,
 } from "./builders/variable-declaration-list.js";
@@ -221,6 +225,8 @@ export const jsxs = <T>(
         return createFunctionExpression(options as FunctionExpressionProps);
       case "expr:statement":
         return createExpressionStatement(options as ExpressionStatementProps);
+      case "expr:not":
+        return createNotExpression(options as NotExpressionProps);
 
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
@@ -311,6 +317,7 @@ declare global {
       ["expr:call"]: CallExpressionProps;
       ["expr:function"]: FunctionExpressionProps;
       ["expr:statement"]: ExpressionStatementProps;
+      ["expr:not"]: NotExpressionProps;
 
       ["bind:array"]: ArrayBindingProps;
       ["bind:object"]: ObjectBindingProps;

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -115,7 +115,11 @@ import {
   AwaitExpressionProps,
   createAwaitExpression,
   createNotExpression,
+  createTypeofExpression,
+  createYieldExpression,
   NotExpressionProps,
+  TypeofExpressionProps,
+  YieldExpressionProps,
 } from "./builders/unary-expression.js";
 import {
   createVariableDeclarationList,
@@ -231,6 +235,10 @@ export const jsxs = <T>(
         return createNotExpression(options as NotExpressionProps);
       case "expr:await":
         return createAwaitExpression(options as AwaitExpressionProps);
+      case "expr:typeof":
+        return createTypeofExpression(options as TypeofExpressionProps);
+      case "expr:yield_":
+        return createYieldExpression(options as YieldExpressionProps);
 
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
@@ -323,6 +331,8 @@ declare global {
       ["expr:statement"]: ExpressionStatementProps;
       ["expr:not"]: NotExpressionProps;
       ["expr:await"]: AwaitExpressionProps;
+      ["expr:typeof"]: TypeofExpressionProps;
+      ["expr:yield_"]: YieldExpressionProps;
 
       ["bind:array"]: ArrayBindingProps;
       ["bind:object"]: ObjectBindingProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -43,6 +43,7 @@ const _expressions = [
   "call",
   "function",
   "statement",
+  "unary",
 ] as const;
 
 export type ExpressionTypeName = (typeof _expressions)[number];

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -43,7 +43,7 @@ const _expressions = [
   "call",
   "function",
   "statement",
-  "unary",
+  "not",
 ] as const;
 
 export type ExpressionTypeName = (typeof _expressions)[number];
@@ -94,6 +94,7 @@ export const EXPRESSION_TYPES: readonly ExpressionType[] = [
   "expr:template",
   "expr:call",
   "expr:function",
+  "expr:not",
 ];
 
 export const LITERAL_PRIMITIVE_TYPES: readonly LiteralElementType[] = [

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -43,11 +43,46 @@ const _expressions = [
   "call",
   "function",
   "statement",
-  "not",
 ] as const;
 
-export type ExpressionTypeName = (typeof _expressions)[number];
-export type ExpressionType = `expr:${ExpressionTypeName}`;
+const _standalone_exressions = [
+  "template",
+  "function",
+  "statement",
+  "parens",
+  "prop-access",
+  "elem-access",
+] as const;
+
+const _binary_expressions = ["as", "binary"] as const;
+
+const _unary_expressions = [
+  "not",
+  "await",
+  "typeof",
+  "call",
+  "non-null",
+] as const;
+
+export type UnaryExpressionTypeName = (typeof _unary_expressions)[number];
+export type UnaryExpressionType = `expr:${UnaryExpressionTypeName}`;
+
+export type BinaryExpressionTypeName = (typeof _binary_expressions)[number];
+export type BinaryExpressionType = `expr:${BinaryExpressionTypeName}`;
+
+export type StandaloneExpressionTypeName =
+  (typeof _standalone_exressions)[number];
+export type StandaloneExpressionType = `expr:${StandaloneExpressionTypeName}`;
+
+export type ExpressionTypeName =
+  | UnaryExpressionTypeName
+  | BinaryExpressionTypeName
+  | StandaloneExpressionTypeName;
+
+export type ExpressionType =
+  | UnaryExpressionType
+  | BinaryExpressionType
+  | StandaloneExpressionType;
 
 const _types = [
   "primitive",
@@ -84,18 +119,40 @@ export type ElementType =
   | LiteralElementType
   | PassthroughElementType;
 
-export const EXPRESSION_TYPES: readonly ExpressionType[] = [
-  "expr:as",
-  "expr:parens",
-  "expr:binary",
-  "expr:non-null",
-  "expr:prop-access",
+export const STANDLONE_EXPRESSION_TYPES: readonly StandaloneExpressionType[] = [
   "expr:elem-access",
-  "expr:template",
-  "expr:call",
   "expr:function",
-  "expr:not",
+  "expr:parens",
+  "expr:prop-access",
+  "expr:template",
 ];
+
+export function isStandaloneExpressionType(
+  v: string
+): v is StandaloneExpressionType {
+  return STANDLONE_EXPRESSION_TYPES.includes(v as StandaloneExpressionType);
+}
+
+export const BINARY_EXPRESSION_TYPES: readonly BinaryExpressionType[] = [
+  "expr:as",
+  "expr:binary",
+];
+
+export function isBinaryExpressionType(v: string): v is BinaryExpressionType {
+  return BINARY_EXPRESSION_TYPES.includes(v as BinaryExpressionType);
+}
+
+export const UNARY_EXPRESSION_TYPES: readonly UnaryExpressionType[] = [
+  "expr:not",
+  "expr:await",
+  "expr:call",
+  "expr:typeof",
+  "expr:non-null",
+];
+
+export function isUnaryExpressionType(v: string): v is UnaryExpressionType {
+  return UNARY_EXPRESSION_TYPES.includes(v as UnaryExpressionType);
+}
 
 export const LITERAL_PRIMITIVE_TYPES: readonly LiteralElementType[] = [
   "l:number",
@@ -146,7 +203,9 @@ export function isTypeType(v: string) {
 }
 
 export const EXPRESSION_OR_LITERAL_TYPES: readonly ElementType[] = [
-  ...EXPRESSION_TYPES,
+  ...BINARY_EXPRESSION_TYPES,
+  ...UNARY_EXPRESSION_TYPES,
+  ...STANDLONE_EXPRESSION_TYPES,
   ...LITERAL_TYPES,
 ];
 

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -32,19 +32,6 @@ const _literal_object_nodes = ["prop", "getter", "setter"] as const;
 export type LiteralObjectNodeTypeName = (typeof _literal_object_nodes)[number];
 export type LiteralObjectNodeType = `l:object-${LiteralObjectNodeTypeName}`;
 
-const _expressions = [
-  "as",
-  "binary",
-  "non-null",
-  "parens",
-  "prop-access",
-  "elem-access",
-  "template",
-  "call",
-  "function",
-  "statement",
-] as const;
-
 const _standalone_exressions = [
   "template",
   "function",
@@ -62,6 +49,7 @@ const _unary_expressions = [
   "typeof",
   "call",
   "non-null",
+  "yield_",
 ] as const;
 
 export type UnaryExpressionTypeName = (typeof _unary_expressions)[number];
@@ -148,6 +136,7 @@ export const UNARY_EXPRESSION_TYPES: readonly UnaryExpressionType[] = [
   "expr:call",
   "expr:typeof",
   "expr:non-null",
+  "expr:yield_",
 ];
 
 export function isUnaryExpressionType(v: string): v is UnaryExpressionType {


### PR DESCRIPTION
Unary expressions are those which have a single parameter
```typescript
typeof a; // expr:typeof
await a; // expr:await
yield a; // expr:yield_, yield by itself seems to break keyword stuff
!a; // expr:not
a!; // expr:non-null
a(); // expr:call
```

Calls have been updated a bit to function more like other unary expressions. Unary expressions are opposed to binary expressions like
```typescript
a as string; // expr:as, two values 'a' and 'string'
1 + 2; // expr:binary, two values 1 and 2.
...etc
```