### PR TITLE
Type literals

### DIFF
--- a/jastx-test/tests/method-signature.test.tsx
+++ b/jastx-test/tests/method-signature.test.tsx
@@ -1,0 +1,347 @@
+import { expect, test } from "vitest";
+
+test("t:method renders correctly with no parameters", () => {
+  const v = (
+    <t:method>
+      <ident name="x" />
+      <t:primitive type="string" />
+    </t:method>
+  );
+
+  expect(v.render()).toBe("x():string");
+});
+
+test("t:method renders correctly with a method parameters", () => {
+  const v1 = (
+    <t:method>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+  const v2 = (
+    <t:method>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <param>
+        <ident name="b" />
+        <t:primitive type="string" />
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+  const v3 = (
+    <t:method>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <param modifier="rest">
+        <ident name="b" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+  const v4 = (
+    <t:method>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <param modifier="optional">
+        <ident name="b" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+  const v5 = (
+    <t:method>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+
+  expect(v1.render()).toBe("x(a:number):string");
+  expect(v2.render()).toBe("x(a:number,b:string):string");
+  expect(v3.render()).toBe("x(a:number,...b:number):string");
+  expect(v4.render()).toBe("x(a:number,b?:number):string");
+});
+
+test("t:method renders correctly with type parameters", () => {
+  const v1 = (
+    <t:method>
+      <ident name="x" />
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <param>
+        <ident name="a" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+  const v2 = (
+    <t:method>
+      <ident name="x" />
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <t:param>
+        <ident name="B" />
+        <t:primitive type="string" />
+      </t:param>
+      <param>
+        <ident name="a" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <param>
+        <ident name="b" />
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+
+  expect(v1.render()).toBe("x<T>(a:T):string");
+  expect(v2.render()).toBe("x<T,B extends string>(a:T,b:B):string");
+});
+
+test("t:method renders correctly with optional setting", () => {
+  const v1 = (
+    <t:method optional={true}>
+      <ident name="x" />
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <param>
+        <ident name="a" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+  const v2 = (
+    <t:method optional={true}>
+      <ident name="x" />
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <t:param>
+        <ident name="B" />
+        <t:primitive type="string" />
+      </t:param>
+      <param>
+        <ident name="a" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <param>
+        <ident name="b" />
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+
+  expect(v1.render()).toBe("x?<T>(a:T):string");
+  expect(v2.render()).toBe("x?<T,B extends string>(a:T,b:B):string");
+});
+
+test("t:property renders correctly with no parameters", () => {
+  const v = (
+    <t:property>
+      <ident name="x" />
+      <t:primitive type="string" />
+    </t:property>
+  );
+
+  expect(v.render()).toBe("x():string");
+});
+
+test("t:property renders correctly with a property parameters", () => {
+  const v1 = (
+    <t:property>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:property>
+  );
+  const v2 = (
+    <t:property>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <param>
+        <ident name="b" />
+        <t:primitive type="string" />
+      </param>
+      <t:primitive type="string" />
+    </t:property>
+  );
+  const v3 = (
+    <t:property>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <param modifier="rest">
+        <ident name="b" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:property>
+  );
+  const v4 = (
+    <t:property>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <param modifier="optional">
+        <ident name="b" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:property>
+  );
+  const v5 = (
+    <t:property>
+      <ident name="x" />
+      <param>
+        <ident name="a" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:property>
+  );
+
+  expect(v1.render()).toBe("x(a:number):string");
+  expect(v2.render()).toBe("x(a:number,b:string):string");
+  expect(v3.render()).toBe("x(a:number,...b:number):string");
+  expect(v4.render()).toBe("x(a:number,b?:number):string");
+});
+
+test("t:method renders correctly with type parameters", () => {
+  const v1 = (
+    <t:method>
+      <ident name="x" />
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <param>
+        <ident name="a" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+  const v2 = (
+    <t:method>
+      <ident name="x" />
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <t:param>
+        <ident name="B" />
+        <t:primitive type="string" />
+      </t:param>
+      <param>
+        <ident name="a" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <param>
+        <ident name="b" />
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+
+  expect(v1.render()).toBe("x<T>(a:T):string");
+  expect(v2.render()).toBe("x<T,B extends string>(a:T,b:B):string");
+});
+
+test("t:method renders correctly with optional setting", () => {
+  const v1 = (
+    <t:method optional={true}>
+      <ident name="x" />
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <param>
+        <ident name="a" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+  const v2 = (
+    <t:method optional={true}>
+      <ident name="x" />
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <t:param>
+        <ident name="B" />
+        <t:primitive type="string" />
+      </t:param>
+      <param>
+        <ident name="a" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <param>
+        <ident name="b" />
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:method>
+  );
+
+  expect(v1.render()).toBe("x?<T>(a:T):string");
+  expect(v2.render()).toBe("x?<T,B extends string>(a:T,b:B):string");
+});

--- a/jastx-test/tests/type-literal.test.tsx
+++ b/jastx-test/tests/type-literal.test.tsx
@@ -1,0 +1,86 @@
+import { expect, test } from "vitest";
+
+test("t:literal renders an empty object", () => {
+  const v = <t:literal />;
+
+  expect(v.render()).toBe("{}");
+});
+
+test("t:literal renders simple properties", () => {
+  const v = (
+    <t:literal>
+      <t:property>
+        <ident name="x" />
+        <t:primitive type="string" />
+      </t:property>
+      <t:property computed>
+        <ident name="aString" />
+        <t:primitive type="number" />
+      </t:property>
+    </t:literal>
+  );
+
+  expect(v.render()).toBe("{x:string;[aString]:number;}");
+});
+
+test("t:literal renders with construct signatures", () => {
+  const v = (
+    <t:literal>
+      <t:construct>
+        <t:primitive type="number" />
+      </t:construct>
+      <t:property>
+        <ident name="x" />
+        <t:primitive type="string" />
+      </t:property>
+    </t:literal>
+  );
+
+  expect(v.render()).toBe("{new():number;x:string;}");
+});
+
+test("t:literal renders with index signatures", () => {
+  const v = (
+    <t:literal>
+      <t:index>
+        <ident name="k" />
+        <t:primitive type="number" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </t:index>
+      <t:property>
+        <ident name="x" />
+        <t:primitive type="string" />
+      </t:property>
+    </t:literal>
+  );
+
+  expect(v.render()).toBe("{[k:number]:T;x:string;}");
+});
+
+test("t:literal renders with method signatures", () => {
+  const v = (
+    <t:literal>
+      <t:method>
+        <ident name="x" />
+        <t:param>
+          <ident name="T" />
+        </t:param>
+        <param>
+          <ident name="y" />
+          <t:ref>
+            <ident name="T" />
+          </t:ref>
+        </param>
+        <t:primitive type="unknown" />
+      </t:method>
+      <t:property>
+        <ident name="y" />
+        <t:primitive type="string" />
+      </t:property>
+    </t:literal>
+  );
+
+  expect(v.render()).toBe("{x<T>(y:T):unknown;y:string;}");
+});

--- a/jastx-test/tests/type-signature.test.tsx
+++ b/jastx-test/tests/type-signature.test.tsx
@@ -173,31 +173,99 @@ test("t:method renders correctly with optional setting", () => {
   expect(v2.render()).toBe("x?<T,B extends string>(a:T,b:B):string");
 });
 
-test("t:property renders correctly with no parameters", () => {
-  const v = (
+test("t:property renders correctly with identifiers", () => {
+  const v1 = (
     <t:property>
       <ident name="x" />
       <t:primitive type="string" />
     </t:property>
   );
 
-  expect(v.render()).toBe("x():string");
+  expect(v1.render()).toBe("x:string");
 });
 
-test("t:property renders correctly with a property parameters", () => {
+test("t:property renders computed identifiers in square brackets", () => {
+  const v1 = (
+    <t:property computed>
+      <ident name="x" />
+      <t:primitive type="string" />
+    </t:property>
+  );
+
+  expect(v1.render()).toBe("[x]:string");
+});
+
+test("t:property renders in square brackets with number keys", () => {
   const v1 = (
     <t:property>
+      <l:number value={2} />
+      <t:primitive type="string" />
+    </t:property>
+  );
+
+  expect(v1.render()).toBe("[2]:string");
+});
+
+test("t:property renders in square brackets with string keys", () => {
+  const v1 = (
+    <t:property>
+      <l:string value="x" />
+      <t:primitive type="string" />
+    </t:property>
+  );
+
+  expect(v1.render()).toBe('["x"]:string');
+});
+
+test("t:property renders correctly with optional keys", () => {
+  const v1 = (
+    <t:property optional>
       <ident name="x" />
+      <t:primitive type="string" />
+    </t:property>
+  );
+
+  const v2 = (
+    <t:property optional>
+      <l:number value={2} />
+      <t:primitive type="string" />
+    </t:property>
+  );
+
+  const v3 = (
+    <t:property optional>
+      <l:string value="x" />
+      <t:primitive type="string" />
+    </t:property>
+  );
+
+  expect(v1.render()).toBe("x?:string");
+  expect(v2.render()).toBe("[2]?:string");
+  expect(v3.render()).toBe('["x"]?:string');
+});
+
+test("t:construct renders correctly with no parameters", () => {
+  const v = (
+    <t:construct>
+      <t:primitive type="string" />
+    </t:construct>
+  );
+
+  expect(v.render()).toBe("new():string");
+});
+
+test("t:construct renders correctly with a construct parameters", () => {
+  const v1 = (
+    <t:construct>
       <param>
         <ident name="a" />
         <t:primitive type="number" />
       </param>
       <t:primitive type="string" />
-    </t:property>
+    </t:construct>
   );
   const v2 = (
-    <t:property>
-      <ident name="x" />
+    <t:construct>
       <param>
         <ident name="a" />
         <t:primitive type="number" />
@@ -207,11 +275,10 @@ test("t:property renders correctly with a property parameters", () => {
         <t:primitive type="string" />
       </param>
       <t:primitive type="string" />
-    </t:property>
+    </t:construct>
   );
   const v3 = (
-    <t:property>
-      <ident name="x" />
+    <t:construct>
       <param>
         <ident name="a" />
         <t:primitive type="number" />
@@ -221,11 +288,10 @@ test("t:property renders correctly with a property parameters", () => {
         <t:primitive type="number" />
       </param>
       <t:primitive type="string" />
-    </t:property>
+    </t:construct>
   );
   const v4 = (
-    <t:property>
-      <ident name="x" />
+    <t:construct>
       <param>
         <ident name="a" />
         <t:primitive type="number" />
@@ -235,29 +301,27 @@ test("t:property renders correctly with a property parameters", () => {
         <t:primitive type="number" />
       </param>
       <t:primitive type="string" />
-    </t:property>
+    </t:construct>
   );
   const v5 = (
-    <t:property>
-      <ident name="x" />
+    <t:construct>
       <param>
         <ident name="a" />
         <t:primitive type="number" />
       </param>
       <t:primitive type="string" />
-    </t:property>
+    </t:construct>
   );
 
-  expect(v1.render()).toBe("x(a:number):string");
-  expect(v2.render()).toBe("x(a:number,b:string):string");
-  expect(v3.render()).toBe("x(a:number,...b:number):string");
-  expect(v4.render()).toBe("x(a:number,b?:number):string");
+  expect(v1.render()).toBe("new(a:number):string");
+  expect(v2.render()).toBe("new(a:number,b:string):string");
+  expect(v3.render()).toBe("new(a:number,...b:number):string");
+  expect(v4.render()).toBe("new(a:number,b?:number):string");
 });
 
-test("t:method renders correctly with type parameters", () => {
+test("t:construct renders correctly with type parameters", () => {
   const v1 = (
-    <t:method>
-      <ident name="x" />
+    <t:construct>
       <t:param>
         <ident name="T" />
       </t:param>
@@ -268,11 +332,10 @@ test("t:method renders correctly with type parameters", () => {
         </t:ref>
       </param>
       <t:primitive type="string" />
-    </t:method>
+    </t:construct>
   );
   const v2 = (
-    <t:method>
-      <ident name="x" />
+    <t:construct>
       <t:param>
         <ident name="T" />
       </t:param>
@@ -293,55 +356,70 @@ test("t:method renders correctly with type parameters", () => {
         </t:ref>
       </param>
       <t:primitive type="string" />
-    </t:method>
+    </t:construct>
   );
 
-  expect(v1.render()).toBe("x<T>(a:T):string");
-  expect(v2.render()).toBe("x<T,B extends string>(a:T,b:B):string");
+  expect(v1.render()).toBe("new<T>(a:T):string");
+  expect(v2.render()).toBe("new<T,B extends string>(a:T,b:B):string");
 });
 
-test("t:method renders correctly with optional setting", () => {
+test("t:index renders correctly with string,number,symbol index types", () => {
   const v1 = (
-    <t:method optional={true}>
-      <ident name="x" />
-      <t:param>
-        <ident name="T" />
-      </t:param>
-      <param>
-        <ident name="a" />
-        <t:ref>
-          <ident name="T" />
-        </t:ref>
-      </param>
+    <t:index>
+      <ident name="k" />
       <t:primitive type="string" />
-    </t:method>
-  );
-  const v2 = (
-    <t:method optional={true}>
-      <ident name="x" />
-      <t:param>
-        <ident name="T" />
-      </t:param>
-      <t:param>
-        <ident name="B" />
-        <t:primitive type="string" />
-      </t:param>
-      <param>
-        <ident name="a" />
-        <t:ref>
-          <ident name="T" />
-        </t:ref>
-      </param>
-      <param>
-        <ident name="b" />
-        <t:ref>
-          <ident name="B" />
-        </t:ref>
-      </param>
-      <t:primitive type="string" />
-    </t:method>
+      <t:primitive type="unknown" />
+    </t:index>
   );
 
-  expect(v1.render()).toBe("x?<T>(a:T):string");
-  expect(v2.render()).toBe("x?<T,B extends string>(a:T,b:B):string");
+  const v2 = (
+    <t:index>
+      <ident name="k" />
+      <t:primitive type="number" />
+      <t:primitive type="unknown" />
+    </t:index>
+  );
+
+  const v3 = (
+    <t:index>
+      <ident name="k" />
+      <t:primitive type="symbol" />
+      <t:primitive type="unknown" />
+    </t:index>
+  );
+
+  expect(v1.render()).toBe("[k:string]:unknown");
+  expect(v2.render()).toBe("[k:number]:unknown");
+  expect(v3.render()).toBe("[k:symbol]:unknown");
+});
+
+test("t:index throws an error with other primitive types", () => {
+  expect(() => (
+    <t:index>
+      <ident name="k" />
+      <t:primitive type="any" />
+      <t:primitive type="unknown" />
+    </t:index>
+  )).toThrow();
+  expect(() => (
+    <t:index>
+      <ident name="k" />
+      <t:primitive type="unknown" />
+      <t:primitive type="unknown" />
+    </t:index>
+  )).toThrow();
+  expect(() => (
+    <t:index>
+      <ident name="k" />
+      <t:primitive type="boolean" />
+      <t:primitive type="unknown" />
+    </t:index>
+  )).toThrow();
+  expect(() => (
+    <t:index>
+      <ident name="k" />
+      <t:primitive type="void" />
+      <t:primitive type="unknown" />
+    </t:index>
+  )).toThrow();
 });

--- a/jastx/src/builders/type-literal.ts
+++ b/jastx/src/builders/type-literal.ts
@@ -1,7 +1,6 @@
-import { assertMaxChildren, assertNChildren } from "../asserts.js";
 import { createChildWalker } from "../child-walker.js";
 import { InvalidChildrenError } from "../errors.js";
-import { AstNode, EXPRESSION_OR_LITERAL_TYPES, VALUE_TYPES } from "../types.js";
+import { AstNode } from "../types.js";
 
 const type_literal_type = "t:literal";
 
@@ -27,7 +26,7 @@ export function createTypeLiteral(props: TypeLiteralProps): TypeLiteralNode {
   if (walker.remainingChildren.length > 0) {
     throw new InvalidChildrenError(
       type_literal_type,
-      ["t:property", "t:index"],
+      ["t:property", "t:index", "t:construct", "t:method"],
       walker.remainingChildTypes
     );
   }
@@ -35,6 +34,6 @@ export function createTypeLiteral(props: TypeLiteralProps): TypeLiteralNode {
   return {
     type: type_literal_type,
     props,
-    render: () => `{${property_nodes.map((a) => a.render()).join(";")}}`,
+    render: () => `{${property_nodes.map((a) => `${a.render()};`).join("")}}`,
   };
 }

--- a/jastx/src/builders/type-literal.ts
+++ b/jastx/src/builders/type-literal.ts
@@ -1,0 +1,40 @@
+import { assertMaxChildren, assertNChildren } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode, EXPRESSION_OR_LITERAL_TYPES, VALUE_TYPES } from "../types.js";
+
+const type_literal_type = "t:literal";
+
+export interface TypeLiteralProps {
+  children?: any;
+}
+
+export interface TypeLiteralNode extends AstNode {
+  type: typeof type_literal_type;
+  props: TypeLiteralProps;
+}
+
+export function createTypeLiteral(props: TypeLiteralProps): TypeLiteralNode {
+  const walker = createChildWalker(type_literal_type, props);
+
+  const property_nodes = walker.spliceAssertGroup([
+    "t:property",
+    "t:index",
+    "t:construct",
+    "t:method",
+  ]);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type_literal_type,
+      ["t:property", "t:index"],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type: type_literal_type,
+    props,
+    render: () => `{${property_nodes.map((a) => a.render()).join(";")}}`,
+  };
+}

--- a/jastx/src/builders/type-signatures.ts
+++ b/jastx/src/builders/type-signatures.ts
@@ -1,0 +1,108 @@
+import { assertNChildren } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { InvalidSyntaxError } from "../errors.js";
+import { AstNode, TYPE_TYPES } from "../types.js";
+
+const method_signature_type = "t:method";
+
+// Fairly similar to an arrow function, but without the body,
+// and with it's own possible "optional flag"
+export interface MethodSignatureProps {
+  children?: any;
+  optional?: boolean;
+}
+
+export interface MethodSignatureNode extends AstNode {
+  type: typeof method_signature_type;
+  props: MethodSignatureProps;
+}
+
+export function createMethodSignature(
+  props: MethodSignatureProps
+): MethodSignatureNode {
+  const walker = createChildWalker(method_signature_type, props);
+
+  const ident = walker.spliceAssertNext("ident");
+
+  const parameters = walker.spliceAssertGroup("param");
+
+  if (parameters.slice(0, -1).some((a) => a.props.modifier === "rest")) {
+    throw new InvalidSyntaxError(
+      `<${method_signature_type}> may only have a rest parameter as the last parameter`
+    );
+  }
+
+  const type_parameters = walker.spliceAssertGroup("t:param");
+
+  if (walker.remainingChildren.length > 1) {
+    throw new InvalidSyntaxError(
+      `<${method_signature_type}> must only specify a single return type. But found\n: ${walker.remainingChildren
+        .map((a) => `- ${a}`)
+        .join("\n")}`
+    );
+  }
+
+  let type_node = walker.spliceAssertNextOptional([
+    ...TYPE_TYPES,
+    "t:predicate",
+  ]);
+
+  if (!type_node) {
+    throw new InvalidSyntaxError(
+      `<${method_signature_type}> expected method return type but found none`
+    );
+  }
+
+  return {
+    type: method_signature_type,
+    props,
+    render: () => {
+      const t_params =
+        type_parameters.length > 0
+          ? `<${type_parameters.map((a) => a.render()).join(",")}>`
+          : "";
+
+      return `${ident.render()}${
+        props.optional ? "?" : ""
+      }${t_params}(${parameters
+        .map((a) => a.render())
+        .join(",")}):${type_node.render()}`;
+    },
+  };
+}
+
+const property_signature_type = "t:property";
+
+// Fairly similar to an arrow function, but without the body,
+// and with it's own possible "optional flag"
+export interface PropertySignatureProps {
+  children?: any;
+  optional?: boolean;
+}
+
+export interface PropertySignatureNode extends AstNode {
+  type: typeof property_signature_type;
+  props: PropertySignatureProps;
+}
+
+export function createPropertySignature(
+  props: PropertySignatureProps
+): PropertySignatureNode {
+  assertNChildren(property_signature_type, 2, props);
+
+  const walker = createChildWalker(property_signature_type, props);
+
+  // TODO: Template literals are supported sometimes in ways I can't figure out currently.
+  const ident = walker.spliceAssertNext(["ident", "l:string", "l:number"]);
+
+  const type_node = walker.spliceAssertNext([...TYPE_TYPES]);
+
+  return {
+    type: property_signature_type,
+    props,
+    render: () =>
+      `${ident.type === "ident" ? ident.render() : `[${ident.render()}]`}${
+        props.optional ? "?" : ""
+      }${type_node.render()}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -116,6 +116,10 @@ import {
   TypeReferenceProps,
 } from "./builders/type-reference.js";
 import {
+  createMethodSignature,
+  MethodSignatureProps,
+} from "./builders/type-signatures.js";
+import {
   AwaitExpressionProps,
   createAwaitExpression,
   createNotExpression,
@@ -216,6 +220,8 @@ export const jsxs = <T>(
         return createTypeParameter(options as TypeParameterProps);
       case "t:predicate":
         return createTypePredicate(options as TypePredicateProps);
+      case "t:method":
+        return createMethodSignature(options as MethodSignatureProps);
 
       case "expr:non-null":
         return createNonNullExpression(options as NonNullExpressionProps);
@@ -314,6 +320,7 @@ declare global {
       ["t:indexed"]: TypeIndexedProps;
       ["t:param"]: TypeParameterProps;
       ["t:predicate"]: TypePredicateProps;
+      ["t:method"]: MethodSignatureProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -100,6 +100,10 @@ import {
   TypeIndexedProps,
 } from "./builders/type-indexed.js";
 import {
+  createTypeLiteral,
+  TypeLiteralProps,
+} from "./builders/type-literal.js";
+import {
   createTypeParameter,
   TypeParameterProps,
 } from "./builders/type-parameter.js";
@@ -116,8 +120,14 @@ import {
   TypeReferenceProps,
 } from "./builders/type-reference.js";
 import {
+  ConstructSignatureProps,
+  createConstructSignature,
+  createIndexSignature,
   createMethodSignature,
+  createPropertySignature,
+  IndexSignatureProps,
   MethodSignatureProps,
+  PropertySignatureProps,
 } from "./builders/type-signatures.js";
 import {
   AwaitExpressionProps,
@@ -222,6 +232,14 @@ export const jsxs = <T>(
         return createTypePredicate(options as TypePredicateProps);
       case "t:method":
         return createMethodSignature(options as MethodSignatureProps);
+      case "t:property":
+        return createPropertySignature(options as PropertySignatureProps);
+      case "t:construct":
+        return createConstructSignature(options as ConstructSignatureProps);
+      case "t:index":
+        return createIndexSignature(options as IndexSignatureProps);
+      case "t:literal":
+        return createTypeLiteral(options as TypeLiteralProps);
 
       case "expr:non-null":
         return createNonNullExpression(options as NonNullExpressionProps);
@@ -321,6 +339,10 @@ declare global {
       ["t:param"]: TypeParameterProps;
       ["t:predicate"]: TypePredicateProps;
       ["t:method"]: MethodSignatureProps;
+      ["t:property"]: PropertySignatureProps;
+      ["t:construct"]: ConstructSignatureProps;
+      ["t:index"]: IndexSignatureProps;
+      ["t:literal"]: TypeLiteralProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -2,6 +2,8 @@ const _type_primitives = [
   "string",
   "number",
   "boolean",
+  "symbol",
+  "void",
   "any",
   "unknown",
   "never",

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -80,6 +80,13 @@ const _types = [
   "indexed",
   "param",
   "predicate",
+  "literal",
+
+  // Signatures
+  "method",
+  "construct",
+  "property",
+  "index",
 ] as const;
 
 export type TypeElementTypeName = (typeof _types)[number];
@@ -170,9 +177,10 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:ref",
   "t:cond",
   "t:indexed",
+  "t:literal",
   // t:param is only used in functions so it shouldnt be included here generally.
   // t:predicate is only used as a function return type, so is not included here generally.
-];
+] as const;
 
 export const BLOCK_STATEMENTS_AND_DECLARATIONS: readonly ElementType[] = [
   "var:statement",


### PR DESCRIPTION
Adds the basic functionality for type literals so you can create "type objects" like this

```typescript
{ 
  x: unknown; // Property signature
  [someString]: any; // Property signature (computed)
  new(): any; // Construct signature
  methodName(v: string): unknown; // Method signature
  [k: string]: number[]; // Index signature
}
```