### PR TITLE
Add try/catch/finally statement

### DIFF
--- a/jastx-test/tests/try-statement.test.tsx
+++ b/jastx-test/tests/try-statement.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+
+test("stmt:try renders correctly with simple try catch", () => {
+  const v = (
+    <stmt:try>
+      <block />
+      <catch-clause>
+        <ident name="ex" />
+        <block />
+      </catch-clause>
+    </stmt:try>
+  );
+  expect(v.render()).toBe("try{}catch(ex){}");
+});
+
+test("stmt:try renders correctly with only a finally block", () => {
+  const v = (
+    <stmt:try>
+      <block />
+      <block />
+    </stmt:try>
+  );
+  expect(v.render()).toBe("try{}finally{}");
+});
+
+test("stmt:try renders correctly with both a catch and finally block", () => {
+  const v = (
+    <stmt:try>
+      <block />
+      <catch-clause>
+        <ident name="ex" />
+        <block />
+      </catch-clause>
+      <block />
+    </stmt:try>
+  );
+  expect(v.render()).toBe("try{}catch(ex){}finally{}");
+});
+
+test("stmt:try throws if neither catch nor finally are specified", () => {
+  expect(() => (
+    <stmt:try>
+      <block />
+    </stmt:try>
+  )).toThrow();
+});

--- a/jastx/src/asserts.ts
+++ b/jastx/src/asserts.ts
@@ -1,5 +1,13 @@
 import { InvalidSyntaxError } from "./errors.js";
 
+// Only use this in the context of values that you know exist
+// but typescript isn't quite sure.
+export function assertValue<T>(v: T | null | undefined): asserts v is T {
+  if (v === undefined || v === null) {
+    throw new Error(`IMPL BUG: Expected value but none was found`);
+  }
+}
+
 export function assertZeroChildren(name: string, props: any) {
   return assertNChildren(name, 0, props);
 }

--- a/jastx/src/builders/try-statement.ts
+++ b/jastx/src/builders/try-statement.ts
@@ -1,0 +1,78 @@
+import { assertMaxChildren, assertValue } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { InvalidSyntaxError } from "../errors.js";
+import { AstNode, TYPE_TYPES } from "../types.js";
+
+const type = "stmt:try";
+
+export interface TryStatementProps {
+  children: any;
+}
+
+export interface TryStatementNode extends AstNode {
+  type: typeof type;
+  props: TryStatementProps;
+}
+
+export function createTryStatement(props: TryStatementProps): TryStatementNode {
+  assertMaxChildren(type, 3, props);
+
+  const walker = createChildWalker(type, props);
+
+  const [try_block, catch_clause, finally_block] = walker.spliceAssertExactPath(
+    ["block", ["catch-clause", null], ["block", null]],
+    { noTrailing: true }
+  );
+
+  assertValue(try_block);
+
+  if (!catch_clause && !finally_block) {
+    throw new InvalidSyntaxError(
+      `<${type}> must contain either a <catch-clause> or a final <block> or both`
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () =>
+      `try${try_block.render()}${catch_clause ? catch_clause?.render() : ""}${
+        finally_block ? `finally${finally_block.render()}` : ""
+      }`,
+  };
+}
+
+// This is colocated because it's only relevant to try statements
+const catch_type = "catch-clause";
+
+export interface CatchClauseProps {
+  children: any;
+}
+
+export interface CatchClauseNode extends AstNode {
+  type: typeof catch_type;
+  props: CatchClauseProps;
+}
+
+export function createCatchClause(props: CatchClauseProps): CatchClauseNode {
+  assertMaxChildren(catch_type, 3, props);
+
+  const walker = createChildWalker(catch_type, props);
+
+  const [ident_node, ident_type, block] = walker.spliceAssertExactPath(
+    ["ident", [...TYPE_TYPES, null], "block"],
+    { noTrailing: true }
+  );
+
+  assertValue(ident_node);
+  assertValue(block);
+
+  return {
+    type: catch_type,
+    props,
+    render: () =>
+      `catch(${ident_node.render()}${
+        ident_type ? `:${ident_type.render()}` : ""
+      })${block.render()}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -88,6 +88,12 @@ import {
   TemplateExpressionlProps,
 } from "./builders/template-expression.js";
 import {
+  CatchClauseProps,
+  createCatchClause,
+  createTryStatement,
+  TryStatementProps,
+} from "./builders/try-statement.js";
+import {
   createTypeConditional,
   TypeConditionalProps,
 } from "./builders/type-conditional.js";
@@ -181,6 +187,8 @@ export const jsxs = <T>(
         return createParameter(options as ParameterProps);
       case "arrow-function":
         return createArrowFunction(options as ArrowFunctionProps);
+      case "catch-clause":
+        return createCatchClause(options as CatchClauseProps);
 
       // Declarations
       case "dclr:function":
@@ -276,6 +284,8 @@ export const jsxs = <T>(
         return createExpressionStatement(options as ExpressionStatementProps);
       case "stmt:return":
         return createReturnStatement(options as ReturnStatementProps);
+      case "stmt:try":
+        return createTryStatement(options as TryStatementProps);
 
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
@@ -341,12 +351,15 @@ declare global {
       ["block"]: BlockProps;
       ["param"]: ParameterProps;
       ["arrow-function"]: ArrowFunctionProps;
+      ["catch-clause"]: CatchClauseProps;
+
       ["dclr:function"]: FunctionDeclarationProps;
 
       ["stmt:if"]: IfStatementProps;
       ["stmt:expr"]: ExpressionStatementProps;
       ["stmt:var"]: VariableStatementProps;
       ["stmt:return"]: ReturnStatementProps;
+      ["stmt:try"]: TryStatementProps;
 
       ["dclr:var"]: VariableDeclarationProps;
       ["dclr:var-list"]: VariableDeclarationListProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -88,7 +88,7 @@ const _types = [
 export type TypeElementTypeName = (typeof _types)[number];
 export type TypeElementType = `t:${TypeElementTypeName}`;
 
-const _statements = ["expr", "var", "if", "return"] as const;
+const _statements = ["expr", "var", "if", "return", "try"] as const;
 
 export type StatementElementTypeName = (typeof _statements)[number];
 export type StatementElementType = `stmt:${StatementElementTypeName}`;
@@ -104,6 +104,7 @@ export type ElementType =
   | "block"
   | "arrow-function"
   | "param"
+  | "catch-clause"
   | "bind:array"
   | "bind:array-elem"
   | "bind:object"
@@ -181,6 +182,7 @@ export const STATEMENT_TYPES: readonly StatementElementType[] = [
   "stmt:if",
   "stmt:var",
   "stmt:return",
+  "stmt:try",
 ] as const;
 
 export const DECLARATION_TYPES: readonly DeclarationElementType[] = [


### PR DESCRIPTION
Adds the try/catch/finally syntax. The statement itself is a try statement, a catch is implemented with the standalone `<catch-clause>` element, and a finally is implemented with a second block:

```html
<stmt:try>
  <block />
  <catch-clause>
    <ident name="ex" />
    <block />
  </catch-clause>
</stmt:try>
```
becomes
```typescript
try {
}
catch (ex) {
}
```

```html
<stmt:try>
  <block />
  <block />
</stmt:try>
```
becomes
```typescript
try {
}
finally {
}
```

```html
<stmt:try>
  <block />
  <catch-clause>
    <ident name="ex" />
    <block />
  </catch-clause>
  <block />
</stmt:try>
```
becomes
```typescript
try {
}
catch (ex) {
}
finally {
}
```