### PR TITLE
Add for-of statement

### DIFF
--- a/jastx-test/tests/for-of-statement.test.tsx
+++ b/jastx-test/tests/for-of-statement.test.tsx
@@ -1,0 +1,72 @@
+import { expect, test } from "vitest";
+
+test("<stmt:for-of> renders correctly with defaults", () => {
+  const v = (
+    <stmt:for-of>
+      <ident name="a" />
+      <ident name="b" />
+      <block />
+    </stmt:for-of>
+  );
+
+  expect(v.render()).toBe(`for(const a of b){}`);
+});
+
+test("<stmt:for-of> renders correctly with await", () => {
+  const v = (
+    <stmt:for-of await>
+      <ident name="a" />
+      <ident name="b" />
+      <block />
+    </stmt:for-of>
+  );
+
+  expect(v.render()).toBe(`for await(const a of b){}`);
+});
+
+test("<stmt:for-of> renders correctly with other variable kinds", () => {
+  const v1 = (
+    <stmt:for-of variableType="let">
+      <ident name="a" />
+      <ident name="b" />
+      <block />
+    </stmt:for-of>
+  );
+  expect(v1.render()).toBe(`for(let a of b){}`);
+
+  const v2 = (
+    <stmt:for-of variableType="var">
+      <ident name="a" />
+      <ident name="b" />
+      <block />
+    </stmt:for-of>
+  );
+
+  expect(v2.render()).toBe(`for(var a of b){}`);
+});
+
+test("<stmt:for-of> renders blocks correctly", () => {
+  const v2 = (
+    <stmt:for-of variableType="var">
+      <ident name="a" />
+      <ident name="b" />
+      <block>
+        <stmt:return />
+      </block>
+    </stmt:for-of>
+  );
+
+  expect(v2.render()).toBe(`for(var a of b){return;}`);
+});
+
+test("<stmt:for-of> renders individual statements correctly", () => {
+  const v2 = (
+    <stmt:for-of variableType="var">
+      <ident name="a" />
+      <ident name="b" />
+      <stmt:return />
+    </stmt:for-of>
+  );
+
+  expect(v2.render()).toBe(`for(var a of b)return`);
+});

--- a/jastx/src/builders/for-of-statement.ts
+++ b/jastx/src/builders/for-of-statement.ts
@@ -1,0 +1,50 @@
+import { assertNChildren, assertValue } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { AstNode, EXPRESSION_TYPES, STATEMENT_TYPES } from "../types.js";
+
+const type = "stmt:for-of";
+
+export interface ForOfProps {
+  children: AstNode[] | AstNode;
+  await?: boolean;
+  variableType?: "const" | "let" | "var";
+}
+
+export interface ForOfNode extends AstNode {
+  type: typeof type;
+  props: ForOfProps;
+}
+
+export function isForOf(v: AstNode): v is ForOfNode {
+  return v.type === "stmt:for-of";
+}
+
+export function createForOfStatement(props: ForOfProps): ForOfNode {
+  assertNChildren(type, 3, props);
+
+  const { await: _await = false, variableType = "const" } = props;
+
+  const walker = createChildWalker(type, props);
+
+  const [ident, iterable, block] = walker.spliceAssertExactPath(
+    [
+      "ident",
+      ["ident", "l:string", "l:object", "l:array", ...EXPRESSION_TYPES],
+      ["block", ...STATEMENT_TYPES],
+    ],
+    { noTrailing: true }
+  );
+
+  assertValue(ident);
+  assertValue(iterable);
+  assertValue(block);
+
+  return {
+    type: type,
+    props,
+    render: () =>
+      `for${
+        _await ? ` await` : ""
+      }(${variableType} ${ident.render()} of ${iterable.render()})${block.render()}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -34,6 +34,10 @@ import {
   ExpressionStatementProps,
 } from "./builders/expression-statement.js";
 import {
+  createForOfStatement,
+  ForOfProps,
+} from "./builders/for-of-statement.js";
+import {
   createFunctionDeclaration,
   FunctionDeclarationProps,
 } from "./builders/function-declaration.js";
@@ -286,6 +290,8 @@ export const jsxs = <T>(
         return createReturnStatement(options as ReturnStatementProps);
       case "stmt:try":
         return createTryStatement(options as TryStatementProps);
+      case "stmt:for-of":
+        return createForOfStatement(options as ForOfProps);
 
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
@@ -360,6 +366,7 @@ declare global {
       ["stmt:var"]: VariableStatementProps;
       ["stmt:return"]: ReturnStatementProps;
       ["stmt:try"]: TryStatementProps;
+      ["stmt:for-of"]: ForOfProps;
 
       ["dclr:var"]: VariableDeclarationProps;
       ["dclr:var-list"]: VariableDeclarationListProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -88,7 +88,7 @@ const _types = [
 export type TypeElementTypeName = (typeof _types)[number];
 export type TypeElementType = `t:${TypeElementTypeName}`;
 
-const _statements = ["expr", "var", "if", "return", "try"] as const;
+const _statements = ["expr", "var", "if", "return", "try", "for-of"] as const;
 
 export type StatementElementTypeName = (typeof _statements)[number];
 export type StatementElementType = `stmt:${StatementElementTypeName}`;
@@ -183,6 +183,7 @@ export const STATEMENT_TYPES: readonly StatementElementType[] = [
   "stmt:var",
   "stmt:return",
   "stmt:try",
+  "stmt:for-of",
 ] as const;
 
 export const DECLARATION_TYPES: readonly DeclarationElementType[] = [
@@ -204,10 +205,14 @@ export function isTypeType(v: string) {
   return TYPE_TYPES.includes(v as TypeElementType);
 }
 
-export const EXPRESSION_OR_LITERAL_TYPES: readonly ElementType[] = [
+export const EXPRESSION_TYPES = [
   ...BINARY_EXPRESSION_TYPES,
   ...UNARY_EXPRESSION_TYPES,
   ...STANDLONE_EXPRESSION_TYPES,
+];
+
+export const EXPRESSION_OR_LITERAL_TYPES: readonly ElementType[] = [
+  ...EXPRESSION_TYPES,
   ...LITERAL_TYPES,
 ];
 


### PR DESCRIPTION
The for of statement syntax supports the following variations

```typescript
for (const a of b) {
  // stuff
}
```

Await variation
```typescript
for await (const a of b) {
  // stuff
}
```

Variations of variable kinds
```typescript
for (let a of b) {
  // stuff
}

for (var a of b) {
  // stuff
}
```

Single-statement body
```typescript
for (let a of b) a.toString()
```


