### PR TITLE
Add for-in statement

### DIFF
--- a/jastx-test/tests/for-in-statement.test.tsx
+++ b/jastx-test/tests/for-in-statement.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "vitest";
+
+test("<stmt:for-in> renders correctly with defaults", () => {
+  const v = (
+    <stmt:for-in>
+      <ident name="a" />
+      <ident name="b" />
+      <block />
+    </stmt:for-in>
+  );
+
+  expect(v.render()).toBe(`for(const a in b){}`);
+});
+
+test("<stmt:for-in> renders correctly with other variable kinds", () => {
+  const v1 = (
+    <stmt:for-in variableType="let">
+      <ident name="a" />
+      <ident name="b" />
+      <block />
+    </stmt:for-in>
+  );
+  expect(v1.render()).toBe(`for(let a in b){}`);
+
+  const v2 = (
+    <stmt:for-in variableType="var">
+      <ident name="a" />
+      <ident name="b" />
+      <block />
+    </stmt:for-in>
+  );
+
+  expect(v2.render()).toBe(`for(var a in b){}`);
+});
+
+test("<stmt:for-in> renders blocks correctly", () => {
+  const v2 = (
+    <stmt:for-in variableType="var">
+      <ident name="a" />
+      <ident name="b" />
+      <block>
+        <stmt:return />
+      </block>
+    </stmt:for-in>
+  );
+
+  expect(v2.render()).toBe(`for(var a in b){return;}`);
+});
+
+test("<stmt:for-in> renders individual statements correctly", () => {
+  const v2 = (
+    <stmt:for-in variableType="var">
+      <ident name="a" />
+      <ident name="b" />
+      <stmt:return />
+    </stmt:for-in>
+  );
+
+  expect(v2.render()).toBe(`for(var a in b)return`);
+});

--- a/jastx/src/builders/for-in-statement.ts
+++ b/jastx/src/builders/for-in-statement.ts
@@ -2,36 +2,35 @@ import { assertNChildren, assertValue } from "../asserts.js";
 import { createChildWalker } from "../child-walker.js";
 import { AstNode, EXPRESSION_TYPES, STATEMENT_TYPES } from "../types.js";
 
-const type = "stmt:for-of";
+const type = "stmt:for-in";
 
-export interface ForOfStatementProps {
+export interface ForInStatementProps {
   children: AstNode[] | AstNode;
-  await?: boolean;
   variableType?: "const" | "let" | "var";
 }
 
-export interface ForOfStatementNode extends AstNode {
+export interface ForInStatementNode extends AstNode {
   type: typeof type;
-  props: ForOfStatementProps;
+  props: ForInStatementProps;
 }
 
-export function isForOfStatement(v: AstNode): v is ForOfStatementNode {
-  return v.type === "stmt:for-of";
+export function isForInStatement(v: AstNode): v is ForInStatementNode {
+  return v.type === "stmt:for-in";
 }
 
-export function createForOfStatement(
-  props: ForOfStatementProps
-): ForOfStatementNode {
+export function createForInStatement(
+  props: ForInStatementProps
+): ForInStatementNode {
   assertNChildren(type, 3, props);
 
-  const { await: _await = false, variableType = "const" } = props;
+  const { variableType = "const" } = props;
 
   const walker = createChildWalker(type, props);
 
   const [ident, iterable, block] = walker.spliceAssertExactPath(
     [
       "ident",
-      ["ident", "l:string", "l:object", "l:array", ...EXPRESSION_TYPES],
+      ["ident", "l:object", "l:array", "arrow-function", ...EXPRESSION_TYPES],
       ["block", ...STATEMENT_TYPES],
     ],
     { noTrailing: true }
@@ -45,8 +44,6 @@ export function createForOfStatement(
     type: type,
     props,
     render: () =>
-      `for${
-        _await ? ` await` : ""
-      }(${variableType} ${ident.render()} of ${iterable.render()})${block.render()}`,
+      `for(${variableType} ${ident.render()} in ${iterable.render()})${block.render()}`,
   };
 }

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -34,8 +34,12 @@ import {
   ExpressionStatementProps,
 } from "./builders/expression-statement.js";
 import {
+  createForInStatement,
+  ForInStatementProps,
+} from "./builders/for-in-statement.js";
+import {
   createForOfStatement,
-  ForOfProps,
+  ForOfStatementProps,
 } from "./builders/for-of-statement.js";
 import {
   createFunctionDeclaration,
@@ -291,7 +295,9 @@ export const jsxs = <T>(
       case "stmt:try":
         return createTryStatement(options as TryStatementProps);
       case "stmt:for-of":
-        return createForOfStatement(options as ForOfProps);
+        return createForOfStatement(options as ForOfStatementProps);
+      case "stmt:for-in":
+        return createForInStatement(options as ForOfStatementProps);
 
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
@@ -366,7 +372,8 @@ declare global {
       ["stmt:var"]: VariableStatementProps;
       ["stmt:return"]: ReturnStatementProps;
       ["stmt:try"]: TryStatementProps;
-      ["stmt:for-of"]: ForOfProps;
+      ["stmt:for-of"]: ForOfStatementProps;
+      ["stmt:for-in"]: ForInStatementProps;
 
       ["dclr:var"]: VariableDeclarationProps;
       ["dclr:var-list"]: VariableDeclarationListProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -88,7 +88,15 @@ const _types = [
 export type TypeElementTypeName = (typeof _types)[number];
 export type TypeElementType = `t:${TypeElementTypeName}`;
 
-const _statements = ["expr", "var", "if", "return", "try", "for-of"] as const;
+const _statements = [
+  "expr",
+  "var",
+  "if",
+  "return",
+  "try",
+  "for-of",
+  "for-in",
+] as const;
 
 export type StatementElementTypeName = (typeof _statements)[number];
 export type StatementElementType = `stmt:${StatementElementTypeName}`;
@@ -184,6 +192,7 @@ export const STATEMENT_TYPES: readonly StatementElementType[] = [
   "stmt:return",
   "stmt:try",
   "stmt:for-of",
+  "stmt:for-in",
 ] as const;
 
 export const DECLARATION_TYPES: readonly DeclarationElementType[] = [


### PR DESCRIPTION
The for-in statement syntax supports the following variations

```typescript
for (const a in b) {
  // stuff
}
```

Variations of variable kinds
```typescript
for (let a in b) {
  // stuff
}

for (var a in b) {
  // stuff
}
```

Single-statement body
```typescript
for (let a in b) a.toString()
```


