### PR TITLE
Add for statement

### DIFF
--- a/jastx-test/tests/for-statement.test.tsx
+++ b/jastx-test/tests/for-statement.test.tsx
@@ -1,0 +1,112 @@
+import { expect, test } from "vitest";
+
+test("<stmt:for> renders correctly with only a block", () => {
+  const v = (
+    <stmt:for>
+      <block />
+    </stmt:for>
+  );
+
+  expect(v.render()).toBe(`for(;;){}`);
+});
+
+test("<stmt:for> renders correctly with initializer", () => {
+  const v1 = (
+    <stmt:for>
+      <dclr:var-list type="let">
+        <dclr:var>
+          <ident name="i" />
+          <l:number value={0} />
+        </dclr:var>
+      </dclr:var-list>
+      <block />
+    </stmt:for>
+  );
+  expect(v1.render()).toBe(`for(let i=0;;){}`);
+
+  const v2 = (
+    <stmt:for>
+      <dclr:var-list type="let">
+        <dclr:var>
+          <ident name="i" />
+          <l:number value={0} />
+        </dclr:var>
+        <dclr:var>
+          <ident name="x" />
+        </dclr:var>
+      </dclr:var-list>
+      <block />
+    </stmt:for>
+  );
+  expect(v2.render()).toBe(`for(let i=0,x;;){}`);
+});
+
+test("<stmt:for-in> renders correctly with a condition", () => {
+  const v1 = (
+    <stmt:for>
+      <dclr:var-list type="let">
+        <dclr:var>
+          <ident name="i" />
+          <l:number value={0} />
+        </dclr:var>
+      </dclr:var-list>
+      <expr:call>
+        <ident name="shouldContinue" />
+      </expr:call>
+      <block />
+    </stmt:for>
+  );
+
+  expect(v1.render()).toBe(`for(let i=0;shouldContinue();){}`);
+});
+
+test("<stmt:for-in> renders incrementer correctly without a condition", () => {
+  const v1 = (
+    <stmt:for noCondition={true}>
+      <dclr:var-list type="let">
+        <dclr:var>
+          <ident name="i" />
+          <l:number value={0} />
+        </dclr:var>
+      </dclr:var-list>
+      <expr:call>
+        <ident name="incrementer" />
+      </expr:call>
+      <block />
+    </stmt:for>
+  );
+
+  expect(v1.render()).toBe(`for(let i=0;;incrementer()){}`);
+});
+
+test("<stmt:for-in> renders vars, incrementer and condition", () => {
+  const v1 = (
+    <stmt:for>
+      <dclr:var-list type="let">
+        <dclr:var>
+          <ident name="i" />
+          <l:number value={0} />
+        </dclr:var>
+      </dclr:var-list>
+      <expr:call>
+        <ident name="shouldContinue" />
+      </expr:call>
+      <expr:call>
+        <ident name="incrementer" />
+      </expr:call>
+      <block />
+    </stmt:for>
+  );
+
+  expect(v1.render()).toBe(`for(let i=0;shouldContinue();incrementer()){}`);
+});
+
+test("<stmt:for> renders individual statements correctly", () => {
+  const v2 = (
+    <stmt:for>
+      <stmt:return />
+    </stmt:for>
+  );
+
+  expect(v2.render()).toBe(`for(;;)return`);
+});

--- a/jastx/src/builders/for-statement.ts
+++ b/jastx/src/builders/for-statement.ts
@@ -1,0 +1,73 @@
+import { assertMaxChildren, assertValue } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { AstNode, EXPRESSION_TYPES, STATEMENT_TYPES } from "../types.js";
+
+const type = "stmt:for";
+
+export interface ForOfStatementProps {
+  children: AstNode[] | AstNode;
+  /**
+   * Specifies in the amibgguos case of a missing child,
+   * whether that child refers to the condition or the
+   * incrementer. By default, it refers to the incrementer
+   * so this flag can be enabled to explicity refer to
+   * the condition.
+   *
+   * @example
+   * <stmt:for>
+   *   <dclr:var-list>
+   *     ...
+   *   </dclr:var-list>
+   *   <expr:{something} />
+   *   <block />
+   * </stmt:for>
+   *
+   * By default this will render
+   * for ({vars};{expr};) { ... }
+   *
+   * If the noCondition flag is set, this will instead render
+   * for ({vars};;{expr}) { ... }
+   *
+   */
+  noCondition?: boolean;
+}
+
+export interface ForOfStatementNode extends AstNode {
+  type: typeof type;
+  props: ForOfStatementProps;
+}
+
+export function isForOfStatement(v: AstNode): v is ForOfStatementNode {
+  return v.type === "stmt:for";
+}
+
+export function createForOfStatement(
+  props: ForOfStatementProps
+): ForOfStatementNode {
+  assertMaxChildren(type, 4, props);
+
+  const { noCondition = false } = props;
+
+  const walker = createChildWalker(type, props);
+
+  const [varlist, c_a, c_b, block] = walker.spliceAssertExactPath([
+    ["dclr:var-list", null],
+    [...EXPRESSION_TYPES, null],
+    [...EXPRESSION_TYPES, null],
+    ["block", ...STATEMENT_TYPES],
+  ]);
+
+  assertValue(block);
+
+  const condition = c_a && c_b ? c_a : c_a && !noCondition ? c_a : null;
+  const incrementer = c_a && c_b ? c_b : c_a && noCondition ? c_a : null;
+
+  return {
+    type: type,
+    props,
+    render: () =>
+      `for(${varlist ? varlist.render() : ""};${
+        condition ? condition.render() : ""
+      };${incrementer ? incrementer.render() : ""})${block.render()}`,
+  };
+}

--- a/jastx/src/builders/for-statement.ts
+++ b/jastx/src/builders/for-statement.ts
@@ -4,7 +4,7 @@ import { AstNode, EXPRESSION_TYPES, STATEMENT_TYPES } from "../types.js";
 
 const type = "stmt:for";
 
-export interface ForOfStatementProps {
+export interface ForStatementProps {
   children: AstNode[] | AstNode;
   /**
    * Specifies in the amibgguos case of a missing child,
@@ -32,18 +32,16 @@ export interface ForOfStatementProps {
   noCondition?: boolean;
 }
 
-export interface ForOfStatementNode extends AstNode {
+export interface ForStatementNode extends AstNode {
   type: typeof type;
-  props: ForOfStatementProps;
+  props: ForStatementProps;
 }
 
-export function isForOfStatement(v: AstNode): v is ForOfStatementNode {
+export function isForStatement(v: AstNode): v is ForStatementNode {
   return v.type === "stmt:for";
 }
 
-export function createForOfStatement(
-  props: ForOfStatementProps
-): ForOfStatementNode {
+export function createForStatement(props: ForStatementProps): ForStatementNode {
   assertMaxChildren(type, 4, props);
 
   const { noCondition = false } = props;

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -42,6 +42,10 @@ import {
   ForOfStatementProps,
 } from "./builders/for-of-statement.js";
 import {
+  createForStatement,
+  ForStatementProps,
+} from "./builders/for-statement.js";
+import {
   createFunctionDeclaration,
   FunctionDeclarationProps,
 } from "./builders/function-declaration.js";
@@ -298,6 +302,8 @@ export const jsxs = <T>(
         return createForOfStatement(options as ForOfStatementProps);
       case "stmt:for-in":
         return createForInStatement(options as ForOfStatementProps);
+      case "stmt:for":
+        return createForStatement(options as ForStatementProps);
 
       case "bind:array":
         return createArrayBinding(options as ArrayBindingProps);
@@ -374,6 +380,7 @@ declare global {
       ["stmt:try"]: TryStatementProps;
       ["stmt:for-of"]: ForOfStatementProps;
       ["stmt:for-in"]: ForInStatementProps;
+      ["stmt:for"]: ForStatementProps;
 
       ["dclr:var"]: VariableDeclarationProps;
       ["dclr:var-list"]: VariableDeclarationListProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -96,6 +96,7 @@ const _statements = [
   "try",
   "for-of",
   "for-in",
+  "for",
 ] as const;
 
 export type StatementElementTypeName = (typeof _statements)[number];
@@ -193,6 +194,7 @@ export const STATEMENT_TYPES: readonly StatementElementType[] = [
   "stmt:try",
   "stmt:for-of",
   "stmt:for-in",
+  "stmt:for",
 ] as const;
 
 export const DECLARATION_TYPES: readonly DeclarationElementType[] = [


### PR DESCRIPTION
The for statement syntax supports the following variations

Standard loop
```typescript
for (let i = 0; i < 10; i++) { ... }
```

Missing any one part 
```typescript
for (let i = 0; i < 10;) { ... }
for (let i = 0;; i++) { ... }
for (; i < 10; i++) { ... }
```

Missing any two parts
```typescript
for (let i = 0;;) { ... }
for (;; i++) { ... }
for (; i < 10;) { ... }
```

Infinite Loop
```typescript
for (;;) { ... }
```

Single-statement body
```typescript
for (;;) return
```


