### PR TITLE
Add export declaration syntax

### DIFF
--- a/jastx-test/tests/exports.test.tsx
+++ b/jastx-test/tests/exports.test.tsx
@@ -1,0 +1,138 @@
+import { expect, test } from "vitest";
+
+test("<export-specifier> renders correctly as an identifier", () => {
+  const v1 = (
+    <export-specifier>
+      <ident name="a" />
+    </export-specifier>
+  );
+  expect(v1.render()).toBe("a");
+});
+
+test("<export-specifier> renders correctly with an alias", () => {
+  const v1 = (
+    <export-specifier>
+      <ident name="a" />
+      <ident name="b" />
+    </export-specifier>
+  );
+  expect(v1.render()).toBe("a as b");
+});
+
+test("<export-specifier> renders correctly as type only", () => {
+  const v1 = (
+    <export-specifier typeOnly>
+      <ident name="a" />
+    </export-specifier>
+  );
+  expect(v1.render()).toBe("type a");
+
+  const v2 = (
+    <export-specifier typeOnly>
+      <ident name="a" />
+      <ident name="b" />
+    </export-specifier>
+  );
+  expect(v2.render()).toBe("type a as b");
+});
+
+test("<named-exports> renders correctly with a single export specifier", () => {
+  const v1 = (
+    <named-exports>
+      <export-specifier>
+        <ident name="a" />
+      </export-specifier>
+    </named-exports>
+  );
+  expect(v1.render()).toBe("{a}");
+});
+
+test("<named-exports> renders correctly with just an identifier", () => {
+  const v1 = (
+    <named-exports>
+      <ident name="a" />
+    </named-exports>
+  );
+  expect(v1.render()).toBe("{a}");
+});
+
+test("<named-exports> renders correctly with multiple exports", () => {
+  const v1 = (
+    <named-exports>
+      <ident name="a" />
+      <export-specifier>
+        <ident name="b" />
+      </export-specifier>
+    </named-exports>
+  );
+  expect(v1.render()).toBe("{a,b}");
+});
+
+test("<named-exports> renders correctly with mixed type and non-type exports", () => {
+  const v1 = (
+    <named-exports>
+      <ident name="a" />
+      <export-specifier typeOnly>
+        <ident name="b" />
+      </export-specifier>
+      <export-specifier>
+        <ident name="c" />
+      </export-specifier>
+    </named-exports>
+  );
+  expect(v1.render()).toBe("{a,type b,c}");
+});
+
+test("<namespace-export> renders correctly with a single alias", () => {
+  const v1 = (
+    <namespace-export>
+      <ident name="a" />
+    </namespace-export>
+  );
+  expect(v1.render()).toBe("* as a");
+});
+
+test("<dclr:export> renders by default as a non-aliased namespace", () => {
+  const v1 = (
+    <dclr:export>
+      <l:string value="./test" />
+    </dclr:export>
+  );
+  expect(v1.render()).toBe('export * from "./test"');
+});
+
+test("<dclr:export> renders correctly as type-only", () => {
+  const v1 = (
+    <dclr:export typeOnly>
+      <l:string value="./test" />
+    </dclr:export>
+  );
+  expect(v1.render()).toBe('export type * from "./test"');
+});
+
+test("<dclr:export> renders correctly with named-exports", () => {
+  const v1 = (
+    <dclr:export>
+      <named-exports>
+        <ident name="a" />
+        <export-specifier typeOnly>
+          <ident name="b" />
+        </export-specifier>
+      </named-exports>
+      <l:string value="./test" />
+    </dclr:export>
+  );
+  expect(v1.render()).toBe('export {a,type b} from "./test"');
+});
+
+test("<dclr:export> renders correctly with a namespace export alias", () => {
+  const v1 = (
+    <dclr:export>
+      <namespace-export>
+        <ident name="X" />
+      </namespace-export>
+      <l:string value="./test" />
+    </dclr:export>
+  );
+  expect(v1.render()).toBe('export * as X from "./test"');
+});

--- a/jastx-test/tests/exports.test.tsx
+++ b/jastx-test/tests/exports.test.tsx
@@ -136,3 +136,17 @@ test("<dclr:export> renders correctly with a namespace export alias", () => {
   );
   expect(v1.render()).toBe('export * as X from "./test"');
 });
+
+test("<dclr:export> renders without a source if named-exports are used", () => {
+  const v1 = (
+    <dclr:export>
+      <named-exports>
+        <ident name="a" />
+        <export-specifier typeOnly>
+          <ident name="b" />
+        </export-specifier>
+      </named-exports>
+    </dclr:export>
+  );
+  expect(v1.render()).toBe("export {a,type b}");
+});

--- a/jastx-test/tests/type-reference.test.tsx
+++ b/jastx-test/tests/type-reference.test.tsx
@@ -37,14 +37,19 @@ test("t:ref renders with literal primitive generics", () => {
   expect(v.render()).toBe('X<"test",10,true>');
 });
 
-test.skip("t:ref renders with literal type generics", () => {
-  // TODO: Type literal is basically a type object like
-  // { name: string };
-  // const v = (
-  //   <t:ref>
-  //   </t:ref>
-  // );
-  // expect(v.render()).toBe("X<{ name: string }>");
+test("t:ref renders with literal type generics", () => {
+  const v = (
+    <t:ref>
+      <ident name="X" />
+      <t:literal>
+        <t:property>
+          <ident name="name" />
+          <t:primitive type="string" />
+        </t:property>
+      </t:literal>
+    </t:ref>
+  );
+  expect(v.render()).toBe("X<{name:string;}>");
 });
 
 test.skip("t:ref renders with tuple type generics", () => {

--- a/jastx/src/builders/exports.ts
+++ b/jastx/src/builders/exports.ts
@@ -1,0 +1,173 @@
+import { assertMaxChildren, assertValue } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError, InvalidSyntaxError } from "../errors.js";
+import { AstNode, TYPE_TYPES } from "../types.js";
+
+const spec_type = "export-specifier";
+
+export interface ExportSpecifierProps {
+  children: any;
+  typeOnly?: boolean;
+}
+
+export interface ExportSpecifierNode extends AstNode {
+  type: typeof spec_type;
+  props: ExportSpecifierProps;
+}
+
+export function createExportSpecifier(
+  props: ExportSpecifierProps
+): ExportSpecifierNode {
+  assertMaxChildren(spec_type, 2, props);
+  const { typeOnly = false } = props;
+
+  const walker = createChildWalker(spec_type, props);
+
+  const [ident, alias] = walker.spliceAssertExactPath(
+    ["ident", ["ident", null]],
+    {
+      noTrailing: true,
+    }
+  );
+
+  assertValue(ident);
+
+  return {
+    type: spec_type,
+    props,
+    render: () =>
+      `${typeOnly ? "type " : ""}${ident.render()}${
+        alias ? ` as ${alias.render()}` : ""
+      }`,
+  };
+}
+
+const ne_type = "named-exports";
+
+export interface NamedExportsProps {
+  children: any;
+}
+
+export interface NamedExportsNode extends AstNode {
+  type: typeof ne_type;
+  props: NamedExportsProps;
+}
+
+export function createNamedExports(props: NamedExportsProps): NamedExportsNode {
+  const walker = createChildWalker(spec_type, props);
+
+  const export_values = walker.spliceAssertGroup(
+    ["ident", "export-specifier"],
+    { size: [1, undefined] }
+  );
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      ne_type,
+      ["ident", "export-specifier"],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type: ne_type,
+    props,
+    render: () => `{${export_values.map((x) => x.render()).join(",")}}`,
+  };
+}
+
+const type = "dclr:export";
+
+export interface ExportDeclarationProps {
+  children: any;
+  typeOnly?: boolean;
+}
+
+export interface ExportDeclarationNode extends AstNode {
+  type: typeof type;
+  props: ExportDeclarationProps;
+}
+
+export function isExportDeclaration(
+  node: AstNode
+): node is ExportDeclarationNode {
+  return node.type === type;
+}
+
+export function createExportDeclaration(
+  props: ExportDeclarationProps
+): ExportDeclarationNode {
+  assertMaxChildren(type, 2, props);
+  const walker = createChildWalker(type, props);
+
+  const [values, source] = walker.spliceAssertExactPath([""]);
+
+  const ident =
+    // Default exports do not require a name
+    props.exported === "default"
+      ? walker.spliceAssertNextOptional("ident")
+      : walker.spliceAssertNext("ident");
+
+  const parameters = walker.spliceAssertGroup("param");
+
+  if (parameters.slice(0, -1).some((a) => a.props.modifier === "rest")) {
+    throw new InvalidSyntaxError(
+      `<${type}> may only have a rest parameter as the last parameter`
+    );
+  }
+
+  const type_parameters = walker.spliceAssertGroup("t:param");
+
+  let type_node = walker.spliceAssertNextOptional([
+    ...TYPE_TYPES,
+    "t:predicate",
+  ]);
+
+  const render_parameters = () => {
+    if (type_parameters.length > 0) {
+      return `<${type_parameters.map((a) => a.render()).join(",")}>(${parameters
+        .map((a) => a.render())
+        .join(",")})`;
+    }
+
+    return `(${parameters.map((a) => a.render()).join(",")})`;
+  };
+
+  const block = walker.spliceAssertNextOptional("block");
+
+  if (!block && props.generator) {
+    throw new InvalidSyntaxError(
+      `<${type}> cannot declare a generator function without a body. A body can be ommitted in the case that this is an overload declaration, but an overload declaration does not specify the generator syntax`
+    );
+  }
+
+  if (walker.remainingChildren.length > 0) {
+    if (block) {
+      throw new InvalidSyntaxError(
+        `<${type}> must only specify a <block>. Found a <block> and then another value:\n- ${walker.remainingChildren[0].render()}`
+      );
+    } else {
+      throw new InvalidSyntaxError(
+        `<${type}> can only specify a <block> as the body. This can be ommitted completely for overloads, but no other type can be used`
+      );
+    }
+  }
+
+  const render_export_modifiers = () =>
+    export_type === "default"
+      ? "export default "
+      : export_type === "named"
+      ? "export "
+      : "";
+
+  return {
+    type,
+    props,
+    render: () =>
+      `${props.async ? "async " : ""}${render_export_modifiers()}function${
+        props.generator ? "*" : ""
+      } ${ident ? ident.render() : ""}${render_parameters()}${
+        type_node ? `:${type_node.render()}` : ""
+      }${block ? block.render() : ""}`,
+  };
+}

--- a/jastx/src/builders/exports.ts
+++ b/jastx/src/builders/exports.ts
@@ -1,7 +1,7 @@
-import { assertMaxChildren, assertValue } from "../asserts.js";
+import { assertMaxChildren, assertNChildren, assertValue } from "../asserts.js";
 import { createChildWalker } from "../child-walker.js";
-import { InvalidChildrenError, InvalidSyntaxError } from "../errors.js";
-import { AstNode, TYPE_TYPES } from "../types.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode } from "../types.js";
 
 const spec_type = "export-specifier";
 
@@ -54,7 +54,7 @@ export interface NamedExportsNode extends AstNode {
 }
 
 export function createNamedExports(props: NamedExportsProps): NamedExportsNode {
-  const walker = createChildWalker(spec_type, props);
+  const walker = createChildWalker(ne_type, props);
 
   const export_values = walker.spliceAssertGroup(
     ["ident", "export-specifier"],
@@ -73,6 +73,33 @@ export function createNamedExports(props: NamedExportsProps): NamedExportsNode {
     type: ne_type,
     props,
     render: () => `{${export_values.map((x) => x.render()).join(",")}}`,
+  };
+}
+
+const ns_type = "namespace-export";
+
+export interface NamespaceExportProps {
+  children: any;
+}
+
+export interface NamespaceExportNode extends AstNode {
+  type: typeof ns_type;
+  props: NamespaceExportProps;
+}
+
+export function createNamespaceExport(
+  props: NamespaceExportProps
+): NamespaceExportNode {
+  assertNChildren(ns_type, 1, props);
+
+  const walker = createChildWalker(ns_type, props);
+
+  const export_name = walker.spliceAssertNext("ident");
+
+  return {
+    type: ns_type,
+    props,
+    render: () => `* as ${export_name.render()}`,
   };
 }
 
@@ -98,76 +125,24 @@ export function createExportDeclaration(
   props: ExportDeclarationProps
 ): ExportDeclarationNode {
   assertMaxChildren(type, 2, props);
+
+  const { typeOnly = false } = props;
+
   const walker = createChildWalker(type, props);
 
-  const [values, source] = walker.spliceAssertExactPath([""]);
-
-  const ident =
-    // Default exports do not require a name
-    props.exported === "default"
-      ? walker.spliceAssertNextOptional("ident")
-      : walker.spliceAssertNext("ident");
-
-  const parameters = walker.spliceAssertGroup("param");
-
-  if (parameters.slice(0, -1).some((a) => a.props.modifier === "rest")) {
-    throw new InvalidSyntaxError(
-      `<${type}> may only have a rest parameter as the last parameter`
-    );
-  }
-
-  const type_parameters = walker.spliceAssertGroup("t:param");
-
-  let type_node = walker.spliceAssertNextOptional([
-    ...TYPE_TYPES,
-    "t:predicate",
+  const [values, source] = walker.spliceAssertExactPath([
+    ["named-exports", "namespace-export", null],
+    "l:string",
   ]);
 
-  const render_parameters = () => {
-    if (type_parameters.length > 0) {
-      return `<${type_parameters.map((a) => a.render()).join(",")}>(${parameters
-        .map((a) => a.render())
-        .join(",")})`;
-    }
-
-    return `(${parameters.map((a) => a.render()).join(",")})`;
-  };
-
-  const block = walker.spliceAssertNextOptional("block");
-
-  if (!block && props.generator) {
-    throw new InvalidSyntaxError(
-      `<${type}> cannot declare a generator function without a body. A body can be ommitted in the case that this is an overload declaration, but an overload declaration does not specify the generator syntax`
-    );
-  }
-
-  if (walker.remainingChildren.length > 0) {
-    if (block) {
-      throw new InvalidSyntaxError(
-        `<${type}> must only specify a <block>. Found a <block> and then another value:\n- ${walker.remainingChildren[0].render()}`
-      );
-    } else {
-      throw new InvalidSyntaxError(
-        `<${type}> can only specify a <block> as the body. This can be ommitted completely for overloads, but no other type can be used`
-      );
-    }
-  }
-
-  const render_export_modifiers = () =>
-    export_type === "default"
-      ? "export default "
-      : export_type === "named"
-      ? "export "
-      : "";
+  assertValue(source);
 
   return {
     type,
     props,
     render: () =>
-      `${props.async ? "async " : ""}${render_export_modifiers()}function${
-        props.generator ? "*" : ""
-      } ${ident ? ident.render() : ""}${render_parameters()}${
-        type_node ? `:${type_node.render()}` : ""
-      }${block ? block.render() : ""}`,
+      `export${typeOnly ? " type " : " "}${
+        values ? values.render() : "*"
+      } from ${source.render()}`,
   };
 }

--- a/jastx/src/builders/exports.ts
+++ b/jastx/src/builders/exports.ts
@@ -1,6 +1,6 @@
 import { assertMaxChildren, assertNChildren, assertValue } from "../asserts.js";
 import { createChildWalker } from "../child-walker.js";
-import { InvalidChildrenError } from "../errors.js";
+import { InvalidChildrenError, InvalidSyntaxError } from "../errors.js";
 import { AstNode } from "../types.js";
 
 const spec_type = "export-specifier";
@@ -132,17 +132,21 @@ export function createExportDeclaration(
 
   const [values, source] = walker.spliceAssertExactPath([
     ["named-exports", "namespace-export", null],
-    "l:string",
+    ["l:string", null],
   ]);
 
-  assertValue(source);
+  if ((!values || values.type !== "named-exports") && !source) {
+    throw new InvalidSyntaxError(
+      `<${type}> expects a source <l:string>, unless the value node is a <named-exports> node`
+    );
+  }
 
   return {
     type,
     props,
     render: () =>
-      `export${typeOnly ? " type " : " "}${
-        values ? values.render() : "*"
-      } from ${source.render()}`,
+      `export${typeOnly ? " type " : " "}${values ? values.render() : "*"}${
+        source ? ` from ${source.render()}` : ""
+      }`,
   };
 }

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -34,6 +34,16 @@ import {
   ElementAccessExpressionProps,
 } from "./builders/element-access-expression.js";
 import {
+  createExportDeclaration,
+  createExportSpecifier,
+  createNamedExports,
+  createNamespaceExport,
+  ExportDeclarationProps,
+  ExportSpecifierProps,
+  NamedExportsProps,
+  NamespaceExportProps,
+} from "./builders/exports.js";
+import {
   createExpressionStatement,
   ExpressionStatementProps,
 } from "./builders/expression-statement.js";
@@ -209,6 +219,12 @@ export const jsxs = <T>(
         return createArrowFunction(options as ArrowFunctionProps);
       case "catch-clause":
         return createCatchClause(options as CatchClauseProps);
+      case "named-exports":
+        return createNamedExports(options as NamedExportsProps);
+      case "namespace-export":
+        return createNamespaceExport(options as NamespaceExportProps);
+      case "export-specifier":
+        return createExportSpecifier(options as ExportSpecifierProps);
 
       // Declarations
       case "dclr:function":
@@ -220,6 +236,8 @@ export const jsxs = <T>(
         return createVariableDeclarationList(
           options as VariableDeclarationListProps
         );
+      case "dclr:export":
+        return createExportDeclaration(options as ExportDeclarationProps);
 
       // Literal values
       case "l:boolean":
@@ -382,8 +400,14 @@ declare global {
       ["param"]: ParameterProps;
       ["arrow-function"]: ArrowFunctionProps;
       ["catch-clause"]: CatchClauseProps;
+      ["named-exports"]: NamedExportsProps;
+      ["namespace-export"]: NamespaceExportProps;
+      ["export-specifier"]: ExportSpecifierProps;
 
       ["dclr:function"]: FunctionDeclarationProps;
+      ["dclr:var"]: VariableDeclarationProps;
+      ["dclr:var-list"]: VariableDeclarationListProps;
+      ["dclr:export"]: ExportDeclarationProps;
 
       ["stmt:if"]: IfStatementProps;
       ["stmt:expr"]: ExpressionStatementProps;
@@ -396,8 +420,6 @@ declare global {
       ["stmt:while"]: WhileStatementProps;
       ["stmt:do-while"]: DoWhileStatementProps;
 
-      ["dclr:var"]: VariableDeclarationProps;
-      ["dclr:var-list"]: VariableDeclarationListProps;
       ["expr:as"]: AsExpressionProps;
       ["expr:parens"]: ParensExpressionProps;
       ["expr:non-null"]: NonNullExpressionProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -104,7 +104,7 @@ const _statements = [
 export type StatementElementTypeName = (typeof _statements)[number];
 export type StatementElementType = `stmt:${StatementElementTypeName}`;
 
-const _declarations = ["function", "var", "var-list"] as const;
+const _declarations = ["function", "var", "var-list", "export"] as const;
 
 export type DeclarationElementTypeName = (typeof _declarations)[number];
 export type DeclarationElementType = `dclr:${DeclarationElementTypeName}`;
@@ -116,6 +116,9 @@ export type ElementType =
   | "arrow-function"
   | "param"
   | "catch-clause"
+  | "export-specifier"
+  | "named-exports"
+  | "namespace-export"
   | "bind:array"
   | "bind:array-elem"
   | "bind:object"
@@ -205,7 +208,14 @@ export const DECLARATION_TYPES: readonly DeclarationElementType[] = [
   "dclr:function",
   "dclr:var",
   // var-list is pretty much only allowed inside dclr:var
-  // "dclr:var-list",
+  // "dclr:var-list"
+  // export declarataions are only allowed in the top level
+  // "dclr:export",
+];
+
+export const TOP_LEVEL_DECLARATION_TYPES: readonly DeclarationElementType[] = [
+  ...DECLARATION_TYPES,
+  "dclr:export",
 ];
 
 export function omitFrom(


### PR DESCRIPTION
The export declaration syntax is any exports with a "from" style:
```typescript
export * from './test';
export * as X from './test';
export { a } from './test';
export { a, type b } from './test';
export type * from './test';
export type * as X from './test';
export type { a } from './test';
```

Note that it will happily render the double type syntax, but that's not actually valid
```typescript
export type { a, type b } from './test';
```

This syntax also covers the export syntax without a from, _if_ named exports are used
```typescript
export { a, b, c };
```

For directly exporting top level variables, the export property can be added to the `<stmt:var>` syntax. 
For `default` exports, and `export = value` (not valid in modules), the export assignment type will be added.