### PR TITLE
Add binary expression syntax

### DIFF
--- a/jastx-test/tests/binary-expression.test.tsx
+++ b/jastx-test/tests/binary-expression.test.tsx
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+
+const assignment_operators = [
+  "=",
+  "*=",
+  "/=",
+  "%=",
+  "+=",
+  "-=",
+  "<<=",
+  ">>=",
+  ">>>=",
+  "&=",
+  "^=",
+  "!=",
+  "**=",
+  "&&=",
+  "||=",
+  "??=",
+] as const;
+
+const operator_list = [
+  "+",
+  "-",
+  "/",
+  "*",
+  "**",
+  "%",
+  "<",
+  "<=",
+  "==",
+  ">=",
+  ">",
+  "instanceof",
+  "in",
+  "==",
+  "!=",
+  "===",
+  "!==",
+  "<<",
+  ">>",
+  ">>>",
+  "&",
+  "|",
+  "^",
+  "&&",
+  "||",
+  "??",
+  ...assignment_operators,
+] as const;
+
+test("<expr:binary renders all values correctly", () => {
+  for (const operator of operator_list) {
+    expect(
+      (
+        <expr:binary operator={operator}>
+          <ident name="a" />
+          <ident name="b" />
+        </expr:binary>
+      ).render()
+    ).toBe(`a ${operator} b`);
+  }
+});
+
+test("<expr:binary throws an error when an invalid LHS is used with an assignment operator", () => {
+  for (const operator of assignment_operators) {
+    expect(() => (
+      <expr:binary operator={operator}>
+        <l:number value={10} />
+        <ident name="b" />
+      </expr:binary>
+    )).toThrow();
+  }
+});

--- a/jastx/src/builders/binary-expression.ts
+++ b/jastx/src/builders/binary-expression.ts
@@ -1,0 +1,99 @@
+import { assertNChildren, assertValue } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { AstNode, EXPRESSION_OR_LITERAL_TYPES } from "../types.js";
+
+const type = "expr:binary";
+
+const _arithmetic_operators = ["+", "-", "/", "*", "**", "%"] as const;
+
+const _relational_operators = [
+  "<",
+  "<=",
+  "==",
+  ">=",
+  ">",
+  "instanceof",
+  "in",
+] as const;
+
+const _equality_operators = ["==", "!=", "===", "!=="] as const;
+
+const _bitwise_shift_operators = ["<<", ">>", ">>>"] as const;
+
+const _binary_bitwise_operators = ["&", "|", "^"] as const;
+
+const _binary_logical_operators = ["&&", "||", "??"] as const;
+
+const _assignment_operators = [
+  "=",
+  "*=",
+  "/=",
+  "%=",
+  "+=",
+  "-=",
+  "<<=",
+  ">>=",
+  ">>>=",
+  "&=",
+  "^=",
+  "!=",
+  "**=",
+  "&&=",
+  "||=",
+  "??=",
+] as const;
+
+type ArithmeticOperator = (typeof _arithmetic_operators)[number];
+type RelationalOperator = (typeof _relational_operators)[number];
+type EqualityOperator = (typeof _equality_operators)[number];
+type BitwiseShiftOperator = (typeof _bitwise_shift_operators)[number];
+type BinaryBitwiseOperator = (typeof _binary_bitwise_operators)[number];
+type BinaryLogicalOperator = (typeof _binary_logical_operators)[number];
+type AssignmentOperator = (typeof _assignment_operators)[number];
+
+type BinaryOperator =
+  | ArithmeticOperator
+  | RelationalOperator
+  | EqualityOperator
+  | BitwiseShiftOperator
+  | BinaryBitwiseOperator
+  | BinaryLogicalOperator
+  | AssignmentOperator
+  | ",";
+
+export interface BinaryExpressionProps {
+  children: any;
+  operator: BinaryOperator;
+}
+
+export interface BinaryExpressionNode extends AstNode {
+  type: typeof type;
+  props: BinaryExpressionProps;
+}
+
+export function createBinaryExpression(
+  props: BinaryExpressionProps
+): BinaryExpressionNode {
+  assertNChildren(type, 2, props);
+  const walker = createChildWalker(type, props);
+
+  const [lhs, rhs] = walker.spliceAssertExactPath([
+    _assignment_operators.includes(props.operator as AssignmentOperator)
+      ? ["ident", "expr:elem-access", "expr:prop-access"]
+      : ["ident", ...EXPRESSION_OR_LITERAL_TYPES],
+    // TODO: There's way more to it than this. For example arithmetic expressions
+    // cant have a string RHS. But best to implement it generic for now, and then
+    // come back and really nail all the rules afterwards, otherwise it will give
+    // the false sense of security that it's all correct
+    ["ident", ...EXPRESSION_OR_LITERAL_TYPES],
+  ]);
+
+  assertValue(lhs);
+  assertValue(rhs);
+
+  return {
+    type,
+    props,
+    render: () => `${lhs.render()} ${props.operator} ${rhs.render()}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -7,6 +7,10 @@ import {
   createAsExpression,
 } from "./builders/as-expression.js";
 import {
+  BinaryExpressionProps,
+  createBinaryExpression,
+} from "./builders/binary-expression.js";
+import {
   ArrayBindingElementProps,
   ArrayBindingProps,
   createArrayBinding,
@@ -312,6 +316,8 @@ export const jsxs = <T>(
         return createYieldExpression(options as YieldExpressionProps);
       case "expr:cond":
         return createConditionExpression(options as ConditionExpressionProps);
+      case "expr:binary":
+        return createBinaryExpression(options as BinaryExpressionProps);
 
       // Statements
       case "stmt:if":
@@ -433,6 +439,7 @@ declare global {
       ["expr:typeof"]: TypeofExpressionProps;
       ["expr:yield_"]: YieldExpressionProps;
       ["expr:cond"]: ConditionExpressionProps;
+      ["expr:binary"]: BinaryExpressionProps;
 
       ["bind:array"]: ArrayBindingProps;
       ["bind:object"]: ObjectBindingProps;


### PR DESCRIPTION
Adds a pretty barebones binary expression syntax. Barebones in the sense that it generates a lot of TypeScript errors which can be detected by determining rules for operators and LHS/RHS nodes. The only one it does pick up is the LHS for assignment operators

```typescript
// This will be thrown correctly as an error
1 = 2;
1 ??= 2;
```

