### PR TITLE
Add tuple type syntax

### DIFF
--- a/jastx-test/tests/type-tuple.test.tsx
+++ b/jastx-test/tests/type-tuple.test.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+
+test("<t:tuple> renders correctly as empty", () => {
+  const v1 = <t:tuple />;
+
+  expect(v1.render()).toBe("[]");
+});
+
+test("<t:tuple> renders correctly with contained types", () => {
+  const v1 = (
+    <t:tuple>
+      <t:ref>
+        <ident name="X" />
+      </t:ref>
+      <l:number value={10} />
+      <l:string value="test" />
+    </t:tuple>
+  );
+
+  expect(v1.render()).toBe('[X,10,"test"]');
+});
+
+test("<t:tuple> renders correctly as readonly", () => {
+  const v1 = (
+    <t:tuple readonly>
+      <t:ref>
+        <ident name="X" />
+      </t:ref>
+      <l:number value={10} />
+      <l:string value="test" />
+    </t:tuple>
+  );
+
+  expect(v1.render()).toBe('readonly [X,10,"test"]');
+});

--- a/jastx/src/builders/type-tuple.ts
+++ b/jastx/src/builders/type-tuple.ts
@@ -1,0 +1,48 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode, ElementType, TYPE_TYPES } from "../types.js";
+
+const type = "t:tuple";
+
+export interface TypeTupleProps {
+  readonly?: boolean;
+  children?: any;
+}
+
+export interface TypeTupleNode extends AstNode {
+  type: typeof type;
+  props: TypeTupleProps;
+}
+
+const allowed_types = [
+  ...TYPE_TYPES,
+  "l:bigint",
+  "l:number",
+  "l:string",
+  "l:boolean",
+] satisfies ElementType[];
+
+export function createTypeTuple(props: TypeTupleProps): TypeTupleNode {
+  const { readonly = false } = props;
+
+  const walker = createChildWalker(type, props);
+
+  const types = walker.spliceAssertGroup(allowed_types);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      allowed_types,
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () =>
+      `${readonly ? "readonly " : ""}[${types
+        .map((a) => a.render())
+        .join(",")}]`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -161,6 +161,7 @@ import {
   MethodSignatureProps,
   PropertySignatureProps,
 } from "./builders/type-signatures.js";
+import { createTypeTuple, TypeTupleProps } from "./builders/type-tuple.js";
 import {
   AwaitExpressionProps,
   createAwaitExpression,
@@ -284,6 +285,8 @@ export const jsxs = <T>(
         return createIndexSignature(options as IndexSignatureProps);
       case "t:literal":
         return createTypeLiteral(options as TypeLiteralProps);
+      case "t:tuple":
+        return createTypeTuple(options as TypeTupleProps);
 
       // Expressions
       case "expr:as":
@@ -400,6 +403,7 @@ declare global {
       ["t:construct"]: ConstructSignatureProps;
       ["t:index"]: IndexSignatureProps;
       ["t:literal"]: TypeLiteralProps;
+      ["t:tuple"]: TypeTupleProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -83,6 +83,7 @@ const _types = [
   "construct",
   "property",
   "index",
+  "tuple",
 ] as const;
 
 export type TypeElementTypeName = (typeof _types)[number];
@@ -187,6 +188,7 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:cond",
   "t:indexed",
   "t:literal",
+  "t:tuple",
   // t:param is only used in functions so it shouldnt be included here generally.
   // t:predicate is only used as a function return type, so is not included here generally.
 ] as const;


### PR DESCRIPTION
The tuple type syntax is
```typescript
[X, string, number]
readonly [X, string, number]
```