### PR TITLE
Adds the query type syntax

### DIFF
--- a/jastx-test/tests/type-tuple.test.tsx
+++ b/jastx-test/tests/type-tuple.test.tsx
@@ -28,8 +28,11 @@ test("<t:tuple> renders correctly as readonly", () => {
       </t:ref>
       <l:number value={10} />
       <l:string value="test" />
+      <t:query>
+        <ident name="x" />
+      </t:query>
     </t:tuple>
   );
 
-  expect(v1.render()).toBe('readonly [X,10,"test"]');
+  expect(v1.render()).toBe('readonly [X,10,"test",typeof x]');
 });

--- a/jastx/src/builders/type-query.ts
+++ b/jastx/src/builders/type-query.ts
@@ -1,0 +1,27 @@
+import { assertNChildren } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { AstNode } from "../types.js";
+
+const type = "t:query";
+
+export interface TypeQueryProps {
+  children: any;
+}
+
+export interface TypeQueryNode extends AstNode {
+  type: typeof type;
+  props: TypeQueryProps;
+}
+
+export function createTypeQuery(props: TypeQueryProps): TypeQueryNode {
+  assertNChildren(type, 1, props);
+
+  const walker = createChildWalker(type, props);
+  const ident = walker.spliceAssertNext("ident");
+
+  return {
+    type,
+    props,
+    render: () => `typeof ${ident.render()}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -147,6 +147,7 @@ import {
   createTypePrimitive,
   TypePrimitiveProps,
 } from "./builders/type-primitive.js";
+import { createTypeQuery, TypeQueryProps } from "./builders/type-query.js";
 import {
   createTypeReference,
   TypeReferenceProps,
@@ -287,6 +288,8 @@ export const jsxs = <T>(
         return createTypeLiteral(options as TypeLiteralProps);
       case "t:tuple":
         return createTypeTuple(options as TypeTupleProps);
+      case "t:query":
+        return createTypeQuery(options as TypeQueryProps);
 
       // Expressions
       case "expr:as":
@@ -404,6 +407,7 @@ declare global {
       ["t:index"]: IndexSignatureProps;
       ["t:literal"]: TypeLiteralProps;
       ["t:tuple"]: TypeTupleProps;
+      ["t:query"]: TypeQueryProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -77,13 +77,14 @@ const _types = [
   "param",
   "predicate",
   "literal",
+  "tuple",
+  "query",
 
   // Signatures
   "method",
   "construct",
   "property",
   "index",
-  "tuple",
 ] as const;
 
 export type TypeElementTypeName = (typeof _types)[number];
@@ -189,6 +190,7 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:indexed",
   "t:literal",
   "t:tuple",
+  "t:query",
   // t:param is only used in functions so it shouldnt be included here generally.
   // t:predicate is only used as a function return type, so is not included here generally.
 ] as const;


### PR DESCRIPTION
Very similar to the unary operator `typeof` but this syntax is designed to work inside places that only accept types
```typescript
typeof a
```

Unlike the `typeof` unary operator, the query type only accepts an identifier, so you can't do things like
```typescript
typeof { test: 'value' }
```

But in return it can be used in places that only accept types, like a `t:ref` for instance
```html
<t:ref>
  <ident name="X" />
  <t:query>
    <ident name="a" />
  </t:query>
</t:ref>
```
```typescript
X<typeof a>
```
