### PR TITLE
Add default export syntax

### DIFF
--- a/jastx-test/tests/export-default.test.tsx
+++ b/jastx-test/tests/export-default.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+
+test("<export-default> renders correctly with an identifier", () => {
+  const v1 = (
+    <export-default>
+      <ident name="x" />
+    </export-default>
+  );
+  expect(v1.render()).toBe("export default x");
+});
+
+test("<export-default> renders correctly with literal values", () => {
+  const v1 = (
+    <export-default>
+      <l:array />
+    </export-default>
+  );
+
+  expect(v1.render()).toBe("export default []");
+
+  const v2 = (
+    <export-default>
+      <l:object />
+    </export-default>
+  );
+
+  expect(v2.render()).toBe("export default {}");
+
+  const v3 = (
+    <export-default>
+      <l:string value="" />
+    </export-default>
+  );
+
+  expect(v3.render()).toBe('export default ""');
+});

--- a/jastx/src/builders/export-default.ts
+++ b/jastx/src/builders/export-default.ts
@@ -1,0 +1,35 @@
+import { assertNChildren } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { AstNode, VALUE_TYPES } from "../types.js";
+
+const type = "export-default";
+
+export interface ExportDefaultProps {
+  children: any;
+  typeOnly?: boolean;
+}
+
+export interface ExportDefaultNode extends AstNode {
+  type: typeof type;
+  props: ExportDefaultProps;
+}
+
+export function isExportDefault(node: AstNode): node is ExportDefaultNode {
+  return node.type === type;
+}
+
+export function createExportDefault(
+  props: ExportDefaultProps
+): ExportDefaultNode {
+  assertNChildren(type, 1, props);
+
+  const walker = createChildWalker(type, props);
+
+  const value_node = walker.spliceAssertNext([...VALUE_TYPES]);
+
+  return {
+    type,
+    props,
+    render: () => `export default ${value_node.render()}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -38,6 +38,10 @@ import {
   ElementAccessExpressionProps,
 } from "./builders/element-access-expression.js";
 import {
+  createExportDefault,
+  ExportDefaultProps,
+} from "./builders/export-default.js";
+import {
   createExportDeclaration,
   createExportSpecifier,
   createNamedExports,
@@ -231,6 +235,8 @@ export const jsxs = <T>(
         return createNamespaceExport(options as NamespaceExportProps);
       case "export-specifier":
         return createExportSpecifier(options as ExportSpecifierProps);
+      case "export-default":
+        return createExportDefault(options as ExportDefaultProps);
 
       // Declarations
       case "dclr:function":
@@ -417,6 +423,7 @@ declare global {
       ["named-exports"]: NamedExportsProps;
       ["namespace-export"]: NamespaceExportProps;
       ["export-specifier"]: ExportSpecifierProps;
+      ["export-default"]: ExportDefaultProps;
 
       ["dclr:function"]: FunctionDeclarationProps;
       ["dclr:var"]: VariableDeclarationProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -121,6 +121,7 @@ export type ElementType =
   | "export-specifier"
   | "named-exports"
   | "namespace-export"
+  | "export-default"
   | "bind:array"
   | "bind:array-elem"
   | "bind:object"


### PR DESCRIPTION
This pretty much covers just one type of syntaxt, which obviously is default exports
```typescript
export default x;
export default { test: 'hello' };
export default [1,2,3];
export default () => { console.log('hello'); }
export default function something () { console.log('hello'); }
// ..plus any other literals or expressions.
```