### PR TITLE
Add type function syntax

### DIFF
--- a/jastx-test/tests/builder-tests/type-function.test.tsx
+++ b/jastx-test/tests/builder-tests/type-function.test.tsx
@@ -1,0 +1,126 @@
+import { expect, test } from "vitest";
+
+test("t:function renders correctly with implicit return", () => {
+  const v1 = (
+    <t:function>
+      <l:number value={20} />
+    </t:function>
+  );
+
+  expect(v1.render()).toBe(`()=>20`);
+  const v2 = (
+    <t:function>
+      <t:function>
+        <l:number value={20} />
+      </t:function>
+    </t:function>
+  );
+
+  expect(v2.render()).toBe(`()=>()=>20`);
+});
+
+test("t:function renders correctly with single typed parameter", () => {
+  const v1 = (
+    <t:function>
+      <param>
+        <ident name="x" />
+        <t:primitive type="number" />
+      </param>
+      <t:primitive type="string" />
+    </t:function>
+  );
+
+  expect(v1.render()).toBe(`(x:number)=>string`);
+});
+
+test("t:function renders correctly with multiple parameters", () => {
+  const v1 = (
+    <t:function>
+      <param>
+        <ident name="x" />
+        <t:primitive type="number" />
+      </param>
+      <param>
+        <ident name="y" />
+      </param>
+      <t:primitive type="string" />
+    </t:function>
+  );
+
+  expect(v1.render()).toBe(`(x:number,y)=>string`);
+});
+
+test("t:function renders correctly with type parameters", () => {
+  const v1 = (
+    <t:function>
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <t:param>
+        <ident name="Y" />
+        <t:primitive type="number" />
+      </t:param>
+      <param>
+        <ident name="x" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <t:primitive type="string" />
+    </t:function>
+  );
+
+  expect(v1.render()).toBe(`<T,Y extends number>(x:T)=>string`);
+});
+
+test("t:function renders correctly with return type predicate", () => {
+  const v1 = (
+    <t:function>
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <t:param>
+        <ident name="Y" />
+        <t:primitive type="number" />
+      </t:param>
+      <param>
+        <ident name="x" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <t:predicate>
+        <ident name="x" />
+        <t:primitive type="string" />
+      </t:predicate>
+    </t:function>
+  );
+
+  expect(v1.render()).toBe(`<T,Y extends number>(x:T)=>x is string`);
+});
+
+test("t:function renders correctly with return type asserts predicate", () => {
+  const v1 = (
+    <t:function>
+      <t:param>
+        <ident name="T" />
+      </t:param>
+      <t:param>
+        <ident name="Y" />
+        <t:primitive type="number" />
+      </t:param>
+      <param>
+        <ident name="x" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </param>
+      <t:predicate asserts={true}>
+        <ident name="x" />
+        <t:primitive type="string" />
+      </t:predicate>
+    </t:function>
+  );
+
+  expect(v1.render()).toBe(`<T,Y extends number>(x:T)=>asserts x is string`);
+});

--- a/jastx/src/builders/type-function.ts
+++ b/jastx/src/builders/type-function.ts
@@ -1,0 +1,64 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidSyntaxError } from "../errors.js";
+import { AstNode, TYPE_TYPES } from "../types.js";
+
+const type = "t:function";
+
+export interface TypeFunctionProps {
+  children: any;
+  async?: boolean;
+}
+
+export interface TypeFunctionNode extends AstNode {
+  type: typeof type;
+  props: TypeFunctionProps;
+}
+
+export function createTypeFunction(props: TypeFunctionProps): TypeFunctionNode {
+  const walker = createChildWalker(type, props);
+
+  const parameters = walker.spliceAssertGroup("param");
+
+  if (parameters.slice(0, -1).some((a) => a.props.modifier === "rest")) {
+    throw new InvalidSyntaxError(
+      `<${type}> may only have a rest parameter as the last parameter`
+    );
+  }
+
+  const type_parameters = walker.spliceAssertGroup("t:param");
+
+  const render_parameters = () => {
+    if (type_parameters.length > 0) {
+      return `<${type_parameters.map((a) => a.render()).join(",")}>(${parameters
+        .map((a) => a.render())
+        .join(",")})`;
+    }
+
+    return `(${parameters.map((a) => a.render()).join(",")})`;
+  };
+
+  const type_node = walker.spliceAssertNext([
+    ...TYPE_TYPES,
+    "l:string",
+    "l:number",
+    "l:boolean",
+    "l:bigint",
+  ]);
+
+  if (walker.remainingChildren.length > 0) {
+    // TODO: Need a better error than this. One that says basically that
+    // the children might be invalid, or they might have already been used
+    // in cases where only one of a type is required.
+    throw new InvalidSyntaxError(
+      `<${type}> has either too many children, or invalid children:\n${walker.remainingChildTypes
+        .map((a) => `- <${a}>`)
+        .join("\n")}`
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () => `${render_parameters()}=>${type_node.render()}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -132,6 +132,10 @@ import {
   TypeConditionalProps,
 } from "./builders/type-conditional.js";
 import {
+  createTypeFunction,
+  TypeFunctionProps,
+} from "./builders/type-function.js";
+import {
   createTypeIndexed,
   TypeIndexedProps,
 } from "./builders/type-indexed.js";
@@ -296,6 +300,8 @@ export const jsxs = <T>(
         return createTypeTuple(options as TypeTupleProps);
       case "t:query":
         return createTypeQuery(options as TypeQueryProps);
+      case "t:function":
+        return createTypeFunction(options as TypeFunctionProps);
 
       // Expressions
       case "expr:as":
@@ -414,6 +420,7 @@ declare global {
       ["t:literal"]: TypeLiteralProps;
       ["t:tuple"]: TypeTupleProps;
       ["t:query"]: TypeQueryProps;
+      ["t:function"]: TypeFunctionProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -79,6 +79,7 @@ const _types = [
   "literal",
   "tuple",
   "query",
+  "function",
 
   // Signatures
   "method",
@@ -192,6 +193,8 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:literal",
   "t:tuple",
   "t:query",
+  "t:function",
+  "t:predicate",
   // t:param is only used in functions so it shouldnt be included here generally.
   // t:predicate is only used as a function return type, so is not included here generally.
 ] as const;


### PR DESCRIPTION
Type function syntax is superficially similar to arrow functions
```typescript
type F = (a: string) => number
```

The difference being that the return type of a function is denoted with a colon (`: string`) and in an arrow function, the body is marked by the arrow operator (`=> { ... }`). Whereas in a function type, there is no colon syntax, and the arrow operator denotes the return type.

So the arrow function
```typescript
const fun = (x: string): number => { return parseInt(x); }
```

would be typed as
```typescript
(x: string) => number
```

Some other differences:
- Function types do not allow default values for parameters, although that restriction is not implemented in the PR.
- There is no `async` operator. As async functions always return a promise, any async function can be typed if the return type is a Promise
- 