### PR TITLE
Add type interface syntax

### DIFF
--- a/jastx-test/tests/builder-tests/type-interface.test.tsx
+++ b/jastx-test/tests/builder-tests/type-interface.test.tsx
@@ -1,0 +1,175 @@
+import { expect, test } from "vitest";
+
+test("<t:interface_> renders correctly with only an identifier", () => {
+  const v1 = (
+    <t:interface_>
+      <ident name="Test" />
+    </t:interface_>
+  );
+
+  expect(v1.render()).toBe("interface Test{}");
+});
+
+test("<t:interface_> renders as an exported interface", () => {
+  const v1 = (
+    <t:interface_ exported>
+      <ident name="Test" />
+    </t:interface_>
+  );
+
+  expect(v1.render()).toBe("export interface Test{}");
+});
+
+test("<t:interface_> renders correctly with type parameters", () => {
+  const v1 = (
+    <t:interface_ exported>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <t:param>
+        <ident name="Y" />
+      </t:param>
+    </t:interface_>
+  );
+
+  expect(v1.render()).toBe("export interface Test<X,Y>{}");
+});
+
+test("<t:interface_> renders with a simple heritage clause", () => {
+  const v1 = (
+    <t:interface_ exported>
+      <ident name="Test" />
+      <heritage-clause>
+        <ident name="Base" />
+      </heritage-clause>
+    </t:interface_>
+  );
+
+  expect(v1.render()).toBe("export interface Test extends Base{}");
+});
+
+test("<t:interface_> renders with generic heritage clause", () => {
+  const v1 = (
+    <t:interface_ exported>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause>
+        <heritage-ident>
+          <ident name="Base" />
+          <t:param>
+            <ident name="X" />
+          </t:param>
+        </heritage-ident>
+      </heritage-clause>
+    </t:interface_>
+  );
+
+  expect(v1.render()).toBe("export interface Test<X> extends Base<X>{}");
+});
+
+test("<t:interface_> renders with generic heritage clause", () => {
+  const v1 = (
+    <t:interface_ exported>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause>
+        <heritage-ident>
+          <ident name="Base" />
+          <t:param>
+            <ident name="X" />
+          </t:param>
+        </heritage-ident>
+      </heritage-clause>
+    </t:interface_>
+  );
+
+  expect(v1.render()).toBe("export interface Test<X> extends Base<X>{}");
+});
+
+test("<t:interface_> renders simple properties", () => {
+  const v = (
+    <t:interface_>
+      <ident name="Test" />
+      <t:property>
+        <ident name="x" />
+        <t:primitive type="string" />
+      </t:property>
+      <t:property computed>
+        <ident name="aString" />
+        <t:primitive type="number" />
+      </t:property>
+    </t:interface_>
+  );
+
+  expect(v.render()).toBe("interface Test{x:string;[aString]:number;}");
+});
+
+test("<t:interface_> renders with construct signatures", () => {
+  const v = (
+    <t:interface_>
+      <ident name="Test" />
+      <t:construct>
+        <t:primitive type="number" />
+      </t:construct>
+      <t:property>
+        <ident name="x" />
+        <t:primitive type="string" />
+      </t:property>
+    </t:interface_>
+  );
+
+  expect(v.render()).toBe("interface Test{new():number;x:string;}");
+});
+
+test("<t:interface_> renders with index signatures", () => {
+  const v = (
+    <t:interface_>
+      <ident name="Test" />
+      <t:index>
+        <ident name="k" />
+        <t:primitive type="number" />
+        <t:ref>
+          <ident name="T" />
+        </t:ref>
+      </t:index>
+      <t:property>
+        <ident name="x" />
+        <t:primitive type="string" />
+      </t:property>
+    </t:interface_>
+  );
+
+  expect(v.render()).toBe("interface Test{[k:number]:T;x:string;}");
+});
+
+test("<t:interface_> renders with method signatures", () => {
+  const v = (
+    <t:interface_>
+      <ident name="Test" />
+      <t:method>
+        <ident name="x" />
+        <t:param>
+          <ident name="T" />
+        </t:param>
+        <param>
+          <ident name="y" />
+          <t:ref>
+            <ident name="T" />
+          </t:ref>
+        </param>
+        <t:primitive type="unknown" />
+      </t:method>
+      <t:property>
+        <ident name="y" />
+        <t:primitive type="string" />
+      </t:property>
+    </t:interface_>
+  );
+
+  expect(v.render()).toBe("interface Test{x<T>(y:T):unknown;y:string;}");
+});

--- a/jastx/src/builders/heritage-clause.ts
+++ b/jastx/src/builders/heritage-clause.ts
@@ -1,0 +1,78 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode } from "../types.js";
+
+const ident_type = "heritage-ident";
+
+export interface HeritageIdentifierProps {
+  children: any;
+  type?: string;
+}
+
+// This is called an ExpressionWithTypeArguments node in TS, which is dumb
+export interface HeritageIdentifierNode extends AstNode {
+  type: typeof ident_type;
+  props: HeritageIdentifierProps;
+}
+
+export function createHeritageIdentifier(
+  props: HeritageIdentifierProps
+): HeritageIdentifierNode {
+  const walker = createChildWalker(ident_type, props);
+
+  const ident = walker.spliceAssertNext("ident");
+  const types = walker.spliceAssertGroup("t:param");
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      ident_type,
+      ["ident", "t:param"],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type: ident_type,
+    props,
+    render: () =>
+      `${ident.render()}${
+        types.length > 0 ? `<${types.map((a) => a.render()).join(",")}>` : ""
+      }`,
+  };
+}
+
+const type = "heritage-clause";
+
+export interface HeritageClauseProps {
+  children: any;
+  type?: string;
+}
+
+export interface HeritageClauseNode extends AstNode {
+  type: typeof type;
+  props: HeritageClauseProps;
+}
+
+export function createHeritageClause(
+  props: HeritageClauseProps
+): HeritageClauseNode {
+  const walker = createChildWalker(type, props);
+
+  const idents = walker.spliceAssertGroup(["ident", "heritage-ident"]);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      ["ident", "heritage-ident"],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () => {
+      return `extends ${idents.map((a) => a.render()).join(",")}`;
+    },
+  };
+}

--- a/jastx/src/builders/type-interface.ts
+++ b/jastx/src/builders/type-interface.ts
@@ -1,0 +1,62 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode } from "../types.js";
+
+const type_literal_type = "t:interface_";
+
+export interface TypeInterfaceProps {
+  children: any;
+  exported?: boolean;
+}
+
+export interface TypeInterfaceNode extends AstNode {
+  type: typeof type_literal_type;
+  props: TypeInterfaceProps;
+}
+
+export function createTypeInterface(
+  props: TypeInterfaceProps
+): TypeInterfaceNode {
+  const walker = createChildWalker(type_literal_type, props);
+
+  const ident = walker.spliceAssertNext("ident");
+
+  const type_params = walker.spliceAssertGroup("t:param");
+
+  const heritage_clause = walker.spliceAssertNextOptional("heritage-clause");
+
+  const property_nodes = walker.spliceAssertGroup([
+    "t:property",
+    "t:index",
+    "t:construct",
+    "t:method",
+  ]);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type_literal_type,
+      [
+        "t:property",
+        "t:index",
+        "t:construct",
+        "t:method",
+        "heritage-clause",
+        "t:param",
+      ],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type: type_literal_type,
+    props,
+    render: () =>
+      `${props.exported ? "export " : ""}interface ${ident.render()}${
+        type_params.length > 0
+          ? `<${type_params.map((x) => x.render()).join(",")}>`
+          : ""
+      }${heritage_clause ? ` ${heritage_clause.render()}` : ""}{${property_nodes
+        .map((a) => `${a.render()};`)
+        .join("")}}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -75,6 +75,12 @@ import {
   createFunctionExpression,
   FunctionExpressionProps,
 } from "./builders/function-expression.js";
+import {
+  createHeritageClause,
+  createHeritageIdentifier,
+  HeritageClauseProps,
+  HeritageIdentifierProps,
+} from "./builders/heritage-clause.js";
 import { createIdentifier, IdentifierProps } from "./builders/identifier.js";
 import {
   createIfStatement,
@@ -139,6 +145,10 @@ import {
   createTypeIndexed,
   TypeIndexedProps,
 } from "./builders/type-indexed.js";
+import {
+  createTypeInterface,
+  TypeInterfaceProps,
+} from "./builders/type-interface.js";
 import {
   createTypeLiteral,
   TypeLiteralProps,
@@ -241,6 +251,10 @@ export const jsxs = <T>(
         return createExportSpecifier(options as ExportSpecifierProps);
       case "export-default":
         return createExportDefault(options as ExportDefaultProps);
+      case "heritage-clause":
+        return createHeritageClause(options as HeritageClauseProps);
+      case "heritage-ident":
+        return createHeritageIdentifier(options as HeritageIdentifierProps);
 
       // Declarations
       case "dclr:function":
@@ -302,6 +316,8 @@ export const jsxs = <T>(
         return createTypeQuery(options as TypeQueryProps);
       case "t:function":
         return createTypeFunction(options as TypeFunctionProps);
+      case "t:interface_":
+        return createTypeInterface(options as TypeInterfaceProps);
 
       // Expressions
       case "expr:as":
@@ -421,6 +437,7 @@ declare global {
       ["t:tuple"]: TypeTupleProps;
       ["t:query"]: TypeQueryProps;
       ["t:function"]: TypeFunctionProps;
+      ["t:interface_"]: TypeInterfaceProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;
@@ -431,6 +448,8 @@ declare global {
       ["namespace-export"]: NamespaceExportProps;
       ["export-specifier"]: ExportSpecifierProps;
       ["export-default"]: ExportDefaultProps;
+      ["heritage-clause"]: HeritageClauseProps;
+      ["heritage-ident"]: HeritageIdentifierProps;
 
       ["dclr:function"]: FunctionDeclarationProps;
       ["dclr:var"]: VariableDeclarationProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -46,7 +46,7 @@ const _unary_expressions = [
   "typeof",
   "call",
   "non-null",
-  "yield_",
+  "yield_", // Reserved word
 ] as const;
 
 export type UnaryExpressionTypeName = (typeof _unary_expressions)[number];
@@ -80,6 +80,7 @@ const _types = [
   "tuple",
   "query",
   "function",
+  "interface_", // Reserved word
 
   // Signatures
   "method",
@@ -123,6 +124,8 @@ export type ElementType =
   | "named-exports"
   | "namespace-export"
   | "export-default"
+  | "heritage-clause"
+  | "heritage-ident"
   | "bind:array"
   | "bind:array-elem"
   | "bind:object"


### PR DESCRIPTION
The interface syntax is basically this
```typescript
interface Example {
  test: string;
}
```

Interfaces are not added to the `TYPE_TYPES` list, as they can only be used in declarations. You can't put an interface in a type parameters for example
```typescript
// invalid
T<interface X { test: string }>
```

And you cant assign an interface declaration to a type
```typescript
// invalid
type T = interface X { test: string; }
```

Interfaces provide their own exports, like type assignments
```typescript
export interface X { test: string };
```

Interfaces can have type parameters
```typescript
export interface X<Y> { test: string; }
```

This PR also introduces heritage clauses, which are used on interfaces and also JS classes.
```typescript
export interface X<Y> extends Base<Y> { test: string; }
```