### PR TITLE
Adjust function declaration to work with standard export-default

### DIFF
--- a/jastx-test/tests/builder-tests/function-declaration.test.tsx
+++ b/jastx-test/tests/builder-tests/function-declaration.test.tsx
@@ -159,7 +159,7 @@ test("dclr:function renders with generator token", () => {
 
 test("dclr:function renders with named export", () => {
   const v1 = (
-    <dclr:function exported="named">
+    <dclr:function exported>
       <ident name="test" />
       <block />
     </dclr:function>
@@ -168,30 +168,9 @@ test("dclr:function renders with named export", () => {
   expect(v1.render()).toBe("export function test(){}");
 });
 
-test("dclr:function renders with default export", () => {
-  const v1 = (
-    <dclr:function exported="default">
-      <ident name="test" />
-      <block />
-    </dclr:function>
-  );
-
-  expect(v1.render()).toBe("export default function test(){}");
-});
-
-test("dclr:function renders with default export and no name", () => {
-  const v1 = (
-    <dclr:function exported="default">
-      <block />
-    </dclr:function>
-  );
-
-  expect(v1.render()).toBe("export default function (){}");
-});
-
-test("dclr:function throws an error if no name is provided and it is not a default export", () => {
+test("dclr:function throws an error if no name is provided", () => {
   expect(() => (
-    <dclr:function exported="named">
+    <dclr:function exported>
       <block />
     </dclr:function>
   )).toThrow();

--- a/jastx/src/builders/function-declaration.ts
+++ b/jastx/src/builders/function-declaration.ts
@@ -11,11 +11,7 @@ export interface FunctionDeclarationProps {
    * it will throw an error if provided without a body
    */
   generator?: boolean;
-  /**
-   * Non-default exports require a name, whereas default exports
-   * do not. We need to specify this here.
-   */
-  exported?: "named" | "default";
+  exported?: boolean;
   async?: boolean;
 }
 
@@ -36,11 +32,7 @@ export function createFunctionDeclaration(
   const walker = createChildWalker(type, props);
   const export_type = props.exported ?? "none";
 
-  const ident =
-    // Default exports do not require a name
-    props.exported === "default"
-      ? walker.spliceAssertNextOptional("ident")
-      : walker.spliceAssertNext("ident");
+  const ident = walker.spliceAssertNext("ident");
 
   const parameters = walker.spliceAssertGroup("param");
 
@@ -87,21 +79,16 @@ export function createFunctionDeclaration(
     }
   }
 
-  const render_export_modifiers = () =>
-    export_type === "default"
-      ? "export default "
-      : export_type === "named"
-      ? "export "
-      : "";
-
   return {
     type,
     props,
     render: () =>
-      `${props.async ? "async " : ""}${render_export_modifiers()}function${
-        props.generator ? "*" : ""
-      } ${ident ? ident.render() : ""}${render_parameters()}${
-        type_node ? `:${type_node.render()}` : ""
-      }${block ? block.render() : ""}`,
+      `${props.exported ? "export " : ""}${
+        props.async ? "async " : ""
+      }function${props.generator ? "*" : ""} ${
+        ident ? ident.render() : ""
+      }${render_parameters()}${type_node ? `:${type_node.render()}` : ""}${
+        block ? block.render() : ""
+      }`,
   };
 }


### PR DESCRIPTION
This PR adjusts function declarations so that they are not able to use default exports, and therefore always require a name. This is a divergence from the typescript AST, where `export default function () {}` is considered a "function declaration" node, whereas anything else like `export default { test: string }` is considered a "export assignment" with a value. That's kind of confusing though because the syntax is the same. In any case, the functionality removed in this PR can be easily replicated by using the standard export-default, with a function expression, which ends up creating the same output anyway, and is more consistent than typescripts AST

```html
<export-default>
  <expr:function>
    <block />
  </expr:function>
</export-default>
```

```typescript
export default function () {}
```