### PR TITLE
Add type alias syntax

### DIFF
--- a/jastx-test/tests/builder-tests/type-alias.test.tsx
+++ b/jastx-test/tests/builder-tests/type-alias.test.tsx
@@ -65,3 +65,37 @@ test("<t:alias> renders with complex conditionals", () => {
 
   expect(v1.render()).toBe("export type Test<X>=X extends Y?A:B");
 });
+
+test("<t:alias> renders with infer types", () => {
+  const v1 = (
+    <t:alias exported>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <t:cond>
+        <t:ref>
+          <ident name="X" />
+        </t:ref>
+        <t:literal>
+          <t:property>
+            <ident name="prop" />
+            <t:infer>
+              <t:param>
+                <ident name="A" />
+              </t:param>
+            </t:infer>
+          </t:property>
+        </t:literal>
+        <t:ref>
+          <ident name="A" />
+        </t:ref>
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </t:cond>
+    </t:alias>
+  );
+
+  expect(v1.render()).toBe("export type Test<X>=X extends {prop:infer A;}?A:B");
+});

--- a/jastx-test/tests/builder-tests/type-alias.test.tsx
+++ b/jastx-test/tests/builder-tests/type-alias.test.tsx
@@ -1,0 +1,67 @@
+import { expect, test } from "vitest";
+
+test("<t:alias> renders correctly with only an identifier", () => {
+  const v1 = (
+    <t:alias>
+      <ident name="Test" />
+      <t:primitive type="string" />
+    </t:alias>
+  );
+
+  expect(v1.render()).toBe("type Test=string");
+});
+
+test("<t:alias> renders as an exported interface", () => {
+  const v1 = (
+    <t:alias exported> 
+      <ident name="Test" />
+      <t:primitive type="string" />
+    </t:alias>
+  );
+
+  expect(v1.render()).toBe("export type Test=string");
+});
+
+test("<t:alias> renders correctly with type parameters", () => {
+  const v1 = (
+    <t:alias exported>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <t:param>
+        <ident name="Y" />
+      </t:param>
+      <t:primitive type="string" />
+    </t:alias>
+  );
+
+  expect(v1.render()).toBe("export type Test<X,Y>=string");
+});
+
+test("<t:alias> renders with complex conditionals", () => {
+  const v1 = (
+    <t:alias exported>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <t:cond>
+        <t:ref>
+          <ident name="X" />
+        </t:ref>
+        <t:ref>
+          <ident name="Y" />
+        </t:ref>
+        <t:ref>
+          <ident name="A" />
+        </t:ref>
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </t:cond>
+    </t:alias>
+  );
+
+  expect(v1.render()).toBe("export type Test<X>=X extends Y?A:B");
+});

--- a/jastx/src/builders/type-alias.ts
+++ b/jastx/src/builders/type-alias.ts
@@ -1,0 +1,50 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode, TYPE_TYPES } from "../types.js";
+
+const type_literal_type = "t:alias";
+
+export interface TypeAliasProps {
+  children: any;
+  exported?: boolean;
+}
+
+export interface TypeAliasNode extends AstNode {
+  type: typeof type_literal_type;
+  props: TypeAliasProps;
+}
+
+export function createTypeAlias(
+  props: TypeAliasProps
+): TypeAliasNode {
+  const walker = createChildWalker(type_literal_type, props);
+
+  const ident = walker.spliceAssertNext("ident");
+
+  const type_params = walker.spliceAssertGroup("t:param");
+  
+  const value_node = walker.spliceAssertNext([...TYPE_TYPES]);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type_literal_type,
+      [
+        ...TYPE_TYPES,
+        'ident',
+        't:param'
+      ],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type: type_literal_type,
+    props,
+    render: () => 
+      `${props.exported ? "export " : ""}type ${ident.render()}${
+        type_params.length > 0
+          ? `<${type_params.map((x) => x.render()).join(",")}>`
+          : ""
+      }=${value_node.render()}`
+  };
+}

--- a/jastx/src/builders/type-infer.ts
+++ b/jastx/src/builders/type-infer.ts
@@ -1,0 +1,39 @@
+import { assertMaxChildren } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode } from "../types.js";
+
+const type = "t:infer";
+
+export interface TypeInferProps {
+  children: any;
+}
+
+export interface TypeInferNode extends AstNode {
+  type: typeof type;
+  props: TypeInferProps;
+}
+
+export function createTypeInfer(
+  props: TypeInferProps
+): TypeInferNode {
+  assertMaxChildren(type, 1, props);
+
+  const walker = createChildWalker(type, props);
+
+  const ident = walker.spliceAssertNext("t:param");
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      ["t:param"],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type: type,
+    props,
+    render: () => `infer ${ident.render()}`
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -146,6 +146,7 @@ import {
   createTypeIndexed,
   TypeIndexedProps,
 } from "./builders/type-indexed.js";
+import { createTypeInfer, TypeInferProps } from "./builders/type-infer.js";
 import {
   createTypeInterface,
   TypeInterfaceProps,
@@ -321,6 +322,8 @@ export const jsxs = <T>(
         return createTypeInterface(options as TypeInterfaceProps);
       case "t:alias":
         return createTypeAlias(options as TypeAliasProps);
+      case "t:infer":
+        return createTypeInfer(options as TypeInferProps);
 
       // Expressions
       case "expr:as":
@@ -442,6 +445,7 @@ declare global {
       ["t:function"]: TypeFunctionProps;
       ["t:interface_"]: TypeInterfaceProps;
       ["t:alias"]: TypeAliasProps;
+      ["t:infer"]: TypeInferProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -133,6 +133,7 @@ import {
   createTryStatement,
   TryStatementProps,
 } from "./builders/try-statement.js";
+import { createTypeAlias, TypeAliasProps } from "./builders/type-alias.js";
 import {
   createTypeConditional,
   TypeConditionalProps,
@@ -318,6 +319,8 @@ export const jsxs = <T>(
         return createTypeFunction(options as TypeFunctionProps);
       case "t:interface_":
         return createTypeInterface(options as TypeInterfaceProps);
+      case "t:alias":
+        return createTypeAlias(options as TypeAliasProps);
 
       // Expressions
       case "expr:as":
@@ -438,6 +441,7 @@ declare global {
       ["t:query"]: TypeQueryProps;
       ["t:function"]: TypeFunctionProps;
       ["t:interface_"]: TypeInterfaceProps;
+      ["t:alias"]: TypeAliasProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -82,6 +82,7 @@ const _types = [
   "query",
   "function",
   "interface_", // Reserved word
+  "infer",
 
   // Signatures
   "method",
@@ -199,6 +200,11 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:query",
   "t:function",
   "t:predicate",
+  // Infer is only allowed inside conditional extends clauses, but its technically "allowed"
+  // to be contained in a variety of placed _within_ that clause, so we're going to allow it 
+  // here. The blocking needs to happen in higher level objects, such as a type alias, an
+  // interface declaration, or the type conditional
+  "t:infer"
   // t:param is only used in functions so it shouldnt be included here generally.
   // t:predicate is only used as a function return type, so is not included here generally.
 ] as const;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -70,6 +70,7 @@ export type ExpressionType =
   | StandaloneExpressionType;
 
 const _types = [
+  "alias",
   "primitive",
   "ref",
   "cond",


### PR DESCRIPTION
The type alias is pretty much the fundamental way to create types. It is basically the `type X = {type}` syntax.
```typescript
type X = string;
```
Type alias's support their own exports with any seperate export declaration

```html
<t:alias exported>
  <ident name="X" />
  <t:primitive type="string" />
</t:alias>
```

```typescript
export type X = string
```

Type aliases can be used to create conditional logic, and lookup kind of types
```typescript
// type alias with infer
export type GetPropType<X> = X extends { prop: infer P } ? P : never;

type Example = {
  prop: string;
}

// extracting prop type from Example, resolves to string
type ExamplePropType = GetPropType<Example>
```
