### PR TITLE
Add get/set accessor syntax

### DIFF
--- a/jastx-test/tests/builder-tests/get-accessor.test.tsx
+++ b/jastx-test/tests/builder-tests/get-accessor.test.tsx
@@ -1,0 +1,79 @@
+import { expect, test } from "vitest";
+
+test('<get-accessor> renders a basic get block', () => {
+  const v1 = (
+    <get-accessor>
+      <ident name="prop" />
+      <block />
+    </get-accessor>
+  );
+
+  expect(v1.render()).toBe('get prop(){}')
+})
+
+test('<get-accessor> renders with type parameters', () => {
+  const v1 = (
+    <get-accessor>
+      <ident name="prop" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <block />
+    </get-accessor>
+  );
+
+  expect(v1.render()).toBe('get prop<X>(){}')
+})
+
+test('<get-accessor> renders with result type', () => {
+  const v1 = (
+    <get-accessor>
+      <ident name="prop" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <t:ref>
+        <ident name="X" />
+      </t:ref>
+      <block />
+    </get-accessor>
+  );
+
+  expect(v1.render()).toBe('get prop<X>():X{}')
+})
+
+test('<get-accessor> renders with visibility modifier', () => {
+  const v1 = (
+    <get-accessor modifier="private">
+      <ident name="prop" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <t:ref>
+        <ident name="X" />
+      </t:ref>
+      <block />
+    </get-accessor>
+  );
+
+  expect(v1.render()).toBe('private get prop<X>():X{}')
+})
+
+test('<get-accessor> throws when any parameters are added', () => {
+
+  expect(() => (
+    <get-accessor>
+      <ident name="prop" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <param>
+        <ident name="k" />
+      </param>
+      <t:ref>
+        <ident name="X" />
+      </t:ref>
+      <block />
+    </get-accessor>
+  )).toThrow();
+})

--- a/jastx-test/tests/builder-tests/set-accessor.test.tsx
+++ b/jastx-test/tests/builder-tests/set-accessor.test.tsx
@@ -1,0 +1,85 @@
+import { expect, test } from "vitest";
+
+test('<set-accessor> renders a basic get block', () => {
+  const v1 = (
+    <set-accessor>
+      <ident name="prop" />
+      <param>
+        <ident name="k" />
+      </param>
+      <block />
+    </set-accessor>
+  );
+
+  expect(v1.render()).toBe('set prop(k){}')
+})
+
+test('<set-accessor> renders with type parameters', () => {
+  const v1 = (
+    <set-accessor>
+      <ident name="prop" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <param>
+        <ident name="k" />
+      </param>
+      <block />
+    </set-accessor>
+  );
+
+  expect(v1.render()).toBe('set prop<X>(k){}')
+})
+
+
+test('<set-accessor> renders with visibility modifier', () => {
+  const v1 = (
+    <set-accessor modifier="private">
+      <ident name="prop" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <param>
+        <ident name="k" />
+      </param>
+      <block />
+    </set-accessor>
+  );
+
+  expect(v1.render()).toBe('private set prop<X>(k){}')
+})
+
+test('<set-accessor> throws when no parameters are specified', () => {
+  expect(() => (
+    <set-accessor>
+      <ident name="prop" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <t:ref>
+        <ident name="X" />
+      </t:ref>
+      <block />
+    </set-accessor>
+  )).toThrow();
+})
+test('<set-accessor> throws when more than one parameter is specified', () => {
+  expect(() => (
+    <set-accessor>
+      <ident name="prop" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <param>
+        <ident name="k" />
+      </param>
+      <param>
+        <ident name="v" />
+      </param>
+      <t:ref>
+        <ident name="X" />
+      </t:ref>
+      <block />
+    </set-accessor>
+  )).toThrow();
+})

--- a/jastx-test/tests/builder-tests/variable-declaration-list.test.tsx
+++ b/jastx-test/tests/builder-tests/variable-declaration-list.test.tsx
@@ -76,14 +76,14 @@ test("dclr:var-list renders correctly with non-identifier bindings", () => {
           </bind:object-elem>
         </bind:object>
         <l:object>
-          <l:object-prop>
+          <property>
             <ident name="zz" />
             <l:string value="test" />
-          </l:object-prop>
-          <l:object-prop>
+          </property>
+          <property>
             <ident name="qq" />
             <l:number value={30} />
-          </l:object-prop>
+          </property>
         </l:object>
       </dclr:var>
       <dclr:var>

--- a/jastx/src/builders/get-accessor.ts
+++ b/jastx/src/builders/get-accessor.ts
@@ -1,0 +1,49 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidSyntaxError } from "../errors.js";
+import { AstNode, ModifierType, TYPE_TYPES } from "../types.js";
+
+const type = "get-accessor";
+
+export interface GetAccessorProps {
+  children: any;
+  modifier?: ModifierType;
+}
+
+export interface GetAccessorNode extends AstNode {
+  type: typeof type;
+  props: GetAccessorProps;
+}
+
+export function isGetAccessor(node: AstNode): node is GetAccessorNode {
+  return node.type === type;
+}
+
+export function createGetAccessor(props: GetAccessorProps): GetAccessorNode {
+  const { modifier } = props;
+  const walker = createChildWalker(type, props);
+
+  const ident = walker.spliceAssertNext("ident");
+
+  const type_parameters = walker.spliceAssertGroup("t:param");
+
+  let type_node = walker.spliceAssertNextOptional([...TYPE_TYPES]);
+
+  const block = walker.spliceAssertNext("block");
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidSyntaxError(
+      `<${type}> must only specify a <block>. Found a <block> and then another value:\n- ${walker.remainingChildren[0].render()}`
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () =>
+      `${modifier ? `${modifier} ` : ""}get ${ident.render()}${
+        type_parameters.length > 0
+          ? `<${type_parameters.map((a) => a.render()).join(",")}>`
+          : ""
+      }()${type_node ? `:${type_node.render()}` : ""}${block.render()}`,
+  };
+}

--- a/jastx/src/builders/identifier.ts
+++ b/jastx/src/builders/identifier.ts
@@ -11,6 +11,13 @@ export interface IdentifierProps {
 export interface IdentifierNode extends AstNode {
   type: typeof type;
   props: IdentifierProps;
+  info: {
+    isPrivateIdentifier: boolean
+  }
+}
+
+export function isPrivateIdentifier (node: AstNode): node is IdentifierNode & { info: { isPrivateIdentifier: true }} {
+  return node.type === type && !!node.info?.isPrivateIdentifier;
 }
 
 export function createIdentifier(props: IdentifierProps): IdentifierNode {
@@ -29,6 +36,11 @@ export function createIdentifier(props: IdentifierProps): IdentifierNode {
   return {
     type,
     props,
+    info: {
+      // TODO: Use this later on to error parent components that dont
+      // allow private identifiers.
+      isPrivateIdentifier: props.name[0] === '#'
+    },
     render: () => props.name,
   };
 }

--- a/jastx/src/builders/object-literal.ts
+++ b/jastx/src/builders/object-literal.ts
@@ -1,21 +1,21 @@
 import { assertMaxChildren } from "../asserts.js";
 import { createChildWalker } from "../child-walker.js";
-import { AstNode, EXPRESSION_OR_LITERAL_TYPES, VALUE_TYPES } from "../types.js";
+import { AstNode, VALUE_TYPES } from "../types.js";
 
-const prop_type = "l:object-prop";
+const prop_type = "property";
 
-export interface ObjectPropertyProps {
+export interface PropertyProps {
   children?: any;
 }
 
-export interface ObjectPropertyNode extends AstNode {
+export interface PropertyNode extends AstNode {
   type: typeof prop_type;
-  props: ObjectPropertyProps;
+  props: PropertyProps;
 }
 
-export function createObjectProperty(
-  props: ObjectPropertyProps
-): ObjectPropertyNode {
+export function createProperty(
+  props: PropertyProps
+): PropertyNode {
   assertMaxChildren(prop_type, 2, props);
   const walker = createChildWalker(prop_type, props);
 
@@ -55,9 +55,9 @@ export function createObjectLiteral(
   const walker = createChildWalker(object_type, props);
 
   const property_nodes = walker.spliceAssertGroup([
-    "l:object-prop",
-    "l:object-getter",
-    "l:object-setter",
+    "property",
+    "get-accessor",
+    "set-accessor"
   ]);
 
   return {

--- a/jastx/src/builders/set-accessor.ts
+++ b/jastx/src/builders/set-accessor.ts
@@ -1,0 +1,53 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidSyntaxError } from "../errors.js";
+import { AstNode, ModifierType, TYPE_TYPES } from "../types.js";
+
+const type = "set-accessor";
+
+export interface SetAccessorProps {
+  children: any;
+  modifier?: ModifierType;
+}
+
+export interface SetAccessorNode extends AstNode {
+  type: typeof type;
+  props: SetAccessorProps;
+}
+
+export function isSetAccessor(node: AstNode): node is SetAccessorNode {
+  return node.type === type;
+}
+
+export function createSetAccessor(props: SetAccessorProps): SetAccessorNode {
+  const { modifier } = props;
+  const walker = createChildWalker(type, props);
+
+  const ident = walker.spliceAssertNext("ident");
+
+  const type_parameters = walker.spliceAssertGroup("t:param");
+
+  const params = walker.spliceAssertGroup('param');
+
+  if (params.length !== 1) {
+    throw new InvalidSyntaxError(`<${type}> must have exactly one <param>, but found [${params.length}]`);
+  }
+
+  const block = walker.spliceAssertNext("block");
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidSyntaxError(
+      `<${type}> must only specify a <block>. Found a <block> and then another value:\n- ${walker.remainingChildren[0].render()}`
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () =>
+      `${modifier ? `${modifier} ` : ""}set ${ident.render()}${
+        type_parameters.length > 0
+          ? `<${type_parameters.map((a) => a.render()).join(",")}>`
+          : ""
+      }(${params.map(a => a.render()).join(',')})${block.render()}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -75,6 +75,7 @@ import {
   createFunctionExpression,
   FunctionExpressionProps,
 } from "./builders/function-expression.js";
+import { createGetAccessor, GetAccessorProps } from "./builders/get-accessor.js";
 import {
   createHeritageClause,
   createHeritageIdentifier,
@@ -106,9 +107,9 @@ import {
 } from "./builders/non-null-expression.js";
 import {
   createObjectLiteral,
-  createObjectProperty,
+  createProperty,
   ObjectLiteralProps,
-  ObjectPropertyProps,
+  PropertyProps
 } from "./builders/object-literal.js";
 import { createParameter, ParameterProps } from "./builders/parameter.js";
 import {
@@ -123,6 +124,7 @@ import {
   createReturnStatement,
   ReturnStatementProps,
 } from "./builders/return-statement.js";
+import { createSetAccessor, SetAccessorProps } from "./builders/set-accessor.js";
 import {
   createTemplateExpression,
   TemplateExpressionlProps,
@@ -257,6 +259,12 @@ export const jsxs = <T>(
         return createHeritageClause(options as HeritageClauseProps);
       case "heritage-ident":
         return createHeritageIdentifier(options as HeritageIdentifierProps);
+      case "property":
+        return createProperty(options as PropertyProps);
+      case "get-accessor":
+        return createGetAccessor(options as GetAccessorProps);
+      case "set-accessor":
+        return createSetAccessor(options as SetAccessorProps);
 
       // Declarations
       case "dclr:function":
@@ -284,8 +292,6 @@ export const jsxs = <T>(
         return createBigintLiteral(options as BigintLiteralProps);
       case "l:object":
         return createObjectLiteral(options as ObjectLiteralProps);
-      case "l:object-prop":
-        return createObjectProperty(options as ObjectPropertyProps);
       case "l:array":
         return createArrayLiteral(options as ArrayLiteralProps);
 
@@ -427,8 +433,6 @@ declare global {
       ["l:object"]: ObjectLiteralProps;
       ["l:array"]: ArrayLiteralProps;
 
-      ["l:object-prop"]: ObjectPropertyProps;
-
       ["t:primitive"]: TypePrimitiveProps;
       ["t:ref"]: TypeReferenceProps;
       ["t:cond"]: TypeConditionalProps;
@@ -458,6 +462,9 @@ declare global {
       ["export-default"]: ExportDefaultProps;
       ["heritage-clause"]: HeritageClauseProps;
       ["heritage-ident"]: HeritageIdentifierProps;
+      ["property"]: PropertyProps;
+      ["get-accessor"]: GetAccessorProps;
+      ["set-accessor"]: SetAccessorProps;
 
       ["dclr:function"]: FunctionDeclarationProps;
       ["dclr:var"]: VariableDeclarationProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -24,11 +24,6 @@ const _literals = [
 export type LiteralElementTypeName = (typeof _literals)[number];
 export type LiteralElementType = `l:${LiteralElementTypeName}`;
 
-const _literal_object_nodes = ["prop", "getter", "setter"] as const;
-
-export type LiteralObjectNodeTypeName = (typeof _literal_object_nodes)[number];
-export type LiteralObjectNodeType = `l:object-${LiteralObjectNodeTypeName}`;
-
 const _standalone_exressions = [
   "template",
   "function",
@@ -110,7 +105,7 @@ const _statements = [
 export type StatementElementTypeName = (typeof _statements)[number];
 export type StatementElementType = `stmt:${StatementElementTypeName}`;
 
-const _declarations = ["function", "var", "var-list", "export"] as const;
+const _declarations = ["function", "var", "var-list", "export", "property"] as const;
 
 export type DeclarationElementTypeName = (typeof _declarations)[number];
 export type DeclarationElementType = `dclr:${DeclarationElementTypeName}`;
@@ -132,7 +127,9 @@ export type ElementType =
   | "bind:array-elem"
   | "bind:object"
   | "bind:object-elem"
-  | LiteralObjectNodeType
+  | "get-accessor"
+  | "set-accessor"
+  | 'property'
   | ExpressionType
   | TypeElementType
   | LiteralElementType
@@ -271,6 +268,7 @@ export type AstNode = {
   type: ElementType;
   docs?: AstNode;
   props: any; // TODO: Make this more accurate
+  info?: Record<string, any>
   render: () => string;
 };
 
@@ -289,3 +287,5 @@ export interface JSXSCreationInterface {
 export type WithChildren<T> = T & {
   children?: AstNode[] | any;
 };
+
+export type ModifierType = 'public' | 'private' | 'protected';


### PR DESCRIPTION
The get/set accessor syntax is basically a function with a few extra rules surrounding it
```typescript
get someProperty () {
}

set someProperty (value) {
}
```

For a get accessor, no parameters are allowed to be specified
```typescript
// this is invalid syntax
get someProperty (v) {
}
```
For a set accessor, exactly one parameter must be specified, and no return type can be specified
```typescript
// All examples of invalid syntax
set someProperty () {
}

set someProperty (a, b) {
}

set someProperty (a): string {
}
```

The rules for accessors make sense when you think about how they're used. A get accessor is never called like a function, so there's no way to pass parameters to it

```typescript
const obj = {
  get x () {
    return 20;
  }
}

// Get accessor is called like this
const value_of_x = obj.x
```

A set accessor on the other hand, is called by assigning a value. It cannot have multiple parameters, because assignment operators assign one value only. It can't have no parameters because assignment operators would not have any function if they did not assign at least a single value. And it can not have a return type, because the way it's used means that the return type of the assignment operation is already whatever was assigned. In theory, typescript could allow a return type if it's the exact same type as the single parameter type, but it really serves no purpose and would make things more complicated

```typescript
const obj = {
  v: 20,
  set value (v: number) {
    this.v = v;
  }
}

// Set accessor is called like this
obj.value = 200;

// The result of an assignment is always that value which was assigned
// "output" is 300 here.
const output = (obj.value = 300);
```




