### PR TITLE
Add class syntax

### DIFF
--- a/jastx-test/tests/builder-tests/class.test.tsx
+++ b/jastx-test/tests/builder-tests/class.test.tsx
@@ -1,0 +1,393 @@
+import { expect, test } from "vitest";
+
+test("<dclr:class> renders as a simple class", () => {
+  const v1 = (
+    <dclr:class>
+      <ident name="Test" />
+    </dclr:class>
+  );
+
+  expect(v1.render()).toBe("class Test{}");
+});
+
+test("<dclr:class> throws without an identifier", () => {
+  expect(() => (
+    <dclr:class>
+      <method>
+        <ident name="x" />
+      </method>
+    </dclr:class>
+  )).toThrow();
+});
+
+test("<dclr:class> renders with type parameters", () => {
+  const v1 = (
+    <dclr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+    </dclr:class>
+  );
+
+  expect(v1.render()).toBe("class Test<X>{}");
+});
+
+test("<dclr:class> renders with an extends heritage clause", () => {
+  const v1 = (
+    <dclr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause>
+        <ident name="Base" />
+      </heritage-clause>
+    </dclr:class>
+  );
+
+  expect(v1.render()).toBe("class Test<X> extends Base{}");
+});
+
+test("<dclr:class> renders with an implements heritage clause", () => {
+  const v1 = (
+    <dclr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="implements">
+        <ident name="Base" />
+      </heritage-clause>
+    </dclr:class>
+  );
+
+  expect(v1.render()).toBe("class Test<X> implements Base{}");
+});
+
+test("<dclr:class> renders with both an extends and implements heritage clause", () => {
+  const v1 = (
+    <dclr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="extends">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="implements">
+        <ident name="Root" />
+      </heritage-clause>
+    </dclr:class>
+  );
+
+  expect(v1.render()).toBe("class Test<X> extends Base implements Root{}");
+});
+
+test("<dclr:class> throws with multiple extends, or multiple implements clauses", () => {
+  expect(() => (
+    <dclr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="extends">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="extends">
+        <ident name="Root" />
+      </heritage-clause>
+    </dclr:class>
+  )).toThrow();
+
+  expect(() => (
+    <dclr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="implements">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="implements">
+        <ident name="Root" />
+      </heritage-clause>
+    </dclr:class>
+  )).toThrow();
+});
+
+test("<dclr:class> as an export", () => {
+  const v1 = (
+    <dclr:class exported>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="extends">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="implements">
+        <ident name="Root" />
+      </heritage-clause>
+    </dclr:class>
+  );
+
+  expect(v1.render()).toBe(
+    "export class Test<X> extends Base implements Root{}"
+  );
+});
+
+test("<dclr:class> renders with various property types", () => {
+  const v1 = (
+    <dclr:class exported>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="extends">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="implements">
+        <ident name="Root" />
+      </heritage-clause>
+      <field modifier="private">
+        <ident name="_x" />
+        <l:string value="initial_value" />
+      </field>
+      <get-accessor>
+        <ident name="x" />
+        <block>
+          <stmt:return>
+            <expr:prop-access>
+              <ident name="this" />
+              <ident name="_x" />
+            </expr:prop-access>
+          </stmt:return>
+        </block>
+      </get-accessor>
+      <set-accessor>
+        <ident name="x" />
+        <param>
+          <ident name="value" />
+          <t:primitive type="string" />
+        </param>
+        <block>
+          <stmt:expr>
+            <expr:binary operator="=">
+              <expr:prop-access>
+                <ident name="this" />
+                <ident name="_x" />
+              </expr:prop-access>
+              <ident name="value" />
+            </expr:binary>
+          </stmt:expr>
+        </block>
+      </set-accessor>
+      <method>
+        <ident name="reset" />
+        <block>
+          <stmt:expr>
+            <expr:binary operator="=">
+              <expr:prop-access>
+                <ident name="this" />
+                <ident name="_x" />
+              </expr:prop-access>
+              <l:string value="" />
+            </expr:binary>
+          </stmt:expr>
+        </block>
+      </method>
+    </dclr:class>
+  );
+
+  expect(v1.render()).toBe(
+    'export class Test<X> extends Base implements Root{private _x="initial_value";get x(){return this._x;};set x(value:string){this._x = value;};reset(){this._x = "";}}'
+  );
+});
+
+test("<expr:class> renders as a simple class", () => {
+  const v1 = (
+    <expr:class>
+      <ident name="Test" />
+    </expr:class>
+  );
+
+  expect(v1.render()).toBe("class Test{}");
+});
+
+test("<expr:class> allows an anonymous class", () => {
+  const v1 = (
+    <expr:class>
+      <method>
+        <ident name="x" />
+        <block />
+      </method>
+    </expr:class>
+  );
+
+  expect(v1.render()).toBe("class {x(){}}");
+});
+
+test("<expr:class> renders with type parameters", () => {
+  const v1 = (
+    <expr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+    </expr:class>
+  );
+
+  expect(v1.render()).toBe("class Test<X>{}");
+});
+
+test("<expr:class> renders with an extends heritage clause", () => {
+  const v1 = (
+    <expr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause>
+        <ident name="Base" />
+      </heritage-clause>
+    </expr:class>
+  );
+
+  expect(v1.render()).toBe("class Test<X> extends Base{}");
+});
+
+test("<expr:class> renders with an implements heritage clause", () => {
+  const v1 = (
+    <expr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="implements">
+        <ident name="Base" />
+      </heritage-clause>
+    </expr:class>
+  );
+
+  expect(v1.render()).toBe("class Test<X> implements Base{}");
+});
+
+test("<expr:class> renders with both an extends and implements heritage clause", () => {
+  const v1 = (
+    <expr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="extends">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="implements">
+        <ident name="Root" />
+      </heritage-clause>
+    </expr:class>
+  );
+
+  expect(v1.render()).toBe("class Test<X> extends Base implements Root{}");
+});
+
+test("<expr:class> throws with multiple extends, or multiple implements clauses", () => {
+  expect(() => (
+    <expr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="extends">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="extends">
+        <ident name="Root" />
+      </heritage-clause>
+    </expr:class>
+  )).toThrow();
+
+  expect(() => (
+    <expr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="implements">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="implements">
+        <ident name="Root" />
+      </heritage-clause>
+    </expr:class>
+  )).toThrow();
+});
+
+test("<expr:class> renders with various property types", () => {
+  const v1 = (
+    <expr:class>
+      <ident name="Test" />
+      <t:param>
+        <ident name="X" />
+      </t:param>
+      <heritage-clause kind="extends">
+        <ident name="Base" />
+      </heritage-clause>
+      <heritage-clause kind="implements">
+        <ident name="Root" />
+      </heritage-clause>
+      <field modifier="private">
+        <ident name="_x" />
+        <l:string value="initial_value" />
+      </field>
+      <get-accessor>
+        <ident name="x" />
+        <block>
+          <stmt:return>
+            <expr:prop-access>
+              <ident name="this" />
+              <ident name="_x" />
+            </expr:prop-access>
+          </stmt:return>
+        </block>
+      </get-accessor>
+      <set-accessor>
+        <ident name="x" />
+        <param>
+          <ident name="value" />
+          <t:primitive type="string" />
+        </param>
+        <block>
+          <stmt:expr>
+            <expr:binary operator="=">
+              <expr:prop-access>
+                <ident name="this" />
+                <ident name="_x" />
+              </expr:prop-access>
+              <ident name="value" />
+            </expr:binary>
+          </stmt:expr>
+        </block>
+      </set-accessor>
+      <method>
+        <ident name="reset" />
+        <block>
+          <stmt:expr>
+            <expr:binary operator="=">
+              <expr:prop-access>
+                <ident name="this" />
+                <ident name="_x" />
+              </expr:prop-access>
+              <l:string value="" />
+            </expr:binary>
+          </stmt:expr>
+        </block>
+      </method>
+    </expr:class>
+  );
+
+  expect(v1.render()).toBe(
+    'class Test<X> extends Base implements Root{private _x="initial_value";get x(){return this._x;};set x(value:string){this._x = value;};reset(){this._x = "";}}'
+  );
+});

--- a/jastx/src/builders/class-expression.ts
+++ b/jastx/src/builders/class-expression.ts
@@ -1,0 +1,85 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError, InvalidSyntaxError } from "../errors.js";
+import { AstNode } from "../types.js";
+
+const type = "expr:class";
+
+export interface ClassExpressionProps {
+  children: any;
+}
+
+export interface ClassExpressionNode extends AstNode {
+  type: typeof type;
+  props: ClassExpressionProps;
+}
+
+export function isClassExpression(node: AstNode): node is ClassExpressionNode {
+  return node.type === type;
+}
+
+export function createClassExpression(
+  props: ClassExpressionProps
+): ClassExpressionNode {
+  const walker = createChildWalker(type, props);
+
+  const ident = walker.spliceAssertNextOptional("ident");
+
+  const type_parameters = walker.spliceAssertGroup("t:param");
+
+  const heritage_a = walker.spliceAssertNextOptional("heritage-clause");
+  const heritage_b = walker.spliceAssertNextOptional("heritage-clause");
+
+  if (
+    heritage_a &&
+    heritage_b &&
+    heritage_a.props.kind === heritage_b.props.kind
+  ) {
+    throw new InvalidSyntaxError(
+      `<${type}> cannot have two heritage clauses which are both "extends" or both "implements". It can one of each, only one, or neither`
+    );
+  }
+
+  const ext_node =
+    heritage_a &&
+    (!heritage_a.props.kind || heritage_a.props.kind === "extends")
+      ? heritage_a
+      : heritage_b &&
+        (!heritage_b.props.kind || heritage_b.props.kind === "extends")
+      ? heritage_b
+      : null;
+
+  const imp_node =
+    heritage_a && heritage_a.props.kind === "implements"
+      ? heritage_a
+      : heritage_b && heritage_b.props.kind === "implements"
+      ? heritage_b
+      : null;
+
+  const properties = walker.spliceAssertGroup([
+    "field",
+    "method",
+    "get-accessor",
+    "set-accessor",
+  ]);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      ["field", "method", "get-accessor", "set-accessor"],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () =>
+      `class ${ident ? ident.render() : ""}${
+        type_parameters.length > 0
+          ? `<${type_parameters.map((a) => a.render()).join(",")}>`
+          : ""
+      }${ext_node ? ` ${ext_node.render()}` : ""}${
+        imp_node ? ` ${imp_node.render()}` : ""
+      }{${properties.map((a) => a.render()).join(";")}}`,
+  };
+}

--- a/jastx/src/builders/expression-statement.ts
+++ b/jastx/src/builders/expression-statement.ts
@@ -31,7 +31,13 @@ export function createExpressionStatement(
 
   if (expr_node.type === "expr:function") {
     throw new AmbiguousParserError(
-      `<${type}> can not have an <expr:function> expression inside, because the code produced would be amibguos and ultimately resolved as a function declaration instead. You can just use a function declaration directly here.`
+      `<${type}> can not have an <expr:function> expression inside, because the code produced would be amibiguos and ultimately resolved as a function declaration instead. You can just use a <dclr:function> directly here.`
+    );
+  }
+
+  if (expr_node.type === "expr:class") {
+    throw new AmbiguousParserError(
+      `<${type}> can not have an <expr:class> expression inside, because the code produced would be amibiguos and ultimately resolved as a class declaration instead. You can just use a <dclr:class> directly here.`
     );
   }
 

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -26,6 +26,14 @@ import {
   createCallExpression,
 } from "./builders/call-expression.js";
 import {
+  ClassDeclarationProps,
+  createClassDeclaration,
+} from "./builders/class-declaration.js";
+import {
+  ClassExpressionProps,
+  createClassExpression,
+} from "./builders/class-expression.js";
+import {
   ConditionExpressionProps,
   createConditionExpression,
 } from "./builders/conditional-expression.js";
@@ -76,7 +84,10 @@ import {
   createFunctionExpression,
   FunctionExpressionProps,
 } from "./builders/function-expression.js";
-import { createGetAccessor, GetAccessorProps } from "./builders/get-accessor.js";
+import {
+  createGetAccessor,
+  GetAccessorProps,
+} from "./builders/get-accessor.js";
 import {
   createHeritageClause,
   createHeritageIdentifier,
@@ -111,7 +122,7 @@ import {
   createObjectLiteral,
   createProperty,
   ObjectLiteralProps,
-  PropertyProps
+  PropertyProps,
 } from "./builders/object-literal.js";
 import { createParameter, ParameterProps } from "./builders/parameter.js";
 import {
@@ -126,7 +137,10 @@ import {
   createReturnStatement,
   ReturnStatementProps,
 } from "./builders/return-statement.js";
-import { createSetAccessor, SetAccessorProps } from "./builders/set-accessor.js";
+import {
+  createSetAccessor,
+  SetAccessorProps,
+} from "./builders/set-accessor.js";
 import {
   createTemplateExpression,
   TemplateExpressionlProps,
@@ -284,6 +298,8 @@ export const jsxs = <T>(
         );
       case "dclr:export":
         return createExportDeclaration(options as ExportDeclarationProps);
+      case "dclr:class":
+        return createClassDeclaration(options as ClassDeclarationProps);
 
       // Literal values
       case "l:boolean":
@@ -370,6 +386,8 @@ export const jsxs = <T>(
         return createConditionExpression(options as ConditionExpressionProps);
       case "expr:binary":
         return createBinaryExpression(options as BinaryExpressionProps);
+      case "expr:class":
+        return createClassExpression(options as ClassExpressionProps);
 
       // Statements
       case "stmt:if":
@@ -478,6 +496,7 @@ declare global {
       ["dclr:var"]: VariableDeclarationProps;
       ["dclr:var-list"]: VariableDeclarationListProps;
       ["dclr:export"]: ExportDeclarationProps;
+      ["dclr:class"]: ClassDeclarationProps;
 
       ["stmt:if"]: IfStatementProps;
       ["stmt:expr"]: ExpressionStatementProps;
@@ -504,6 +523,7 @@ declare global {
       ["expr:yield_"]: YieldExpressionProps;
       ["expr:cond"]: ConditionExpressionProps;
       ["expr:binary"]: BinaryExpressionProps;
+      ["expr:class"]: ClassExpressionProps;
 
       ["bind:array"]: ArrayBindingProps;
       ["bind:object"]: ObjectBindingProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -31,6 +31,7 @@ const _standalone_exressions = [
   "prop-access",
   "elem-access",
   "cond",
+  "class",
 ] as const;
 
 const _binary_expressions = ["as", "binary"] as const;
@@ -105,7 +106,14 @@ const _statements = [
 export type StatementElementTypeName = (typeof _statements)[number];
 export type StatementElementType = `stmt:${StatementElementTypeName}`;
 
-const _declarations = ["function", "var", "var-list", "export", "property"] as const;
+const _declarations = [
+  "function",
+  "var",
+  "var-list",
+  "export",
+  "property",
+  "class",
+] as const;
 
 export type DeclarationElementTypeName = (typeof _declarations)[number];
 export type DeclarationElementType = `dclr:${DeclarationElementTypeName}`;
@@ -130,8 +138,8 @@ export type ElementType =
   | "get-accessor"
   | "set-accessor"
   | "method"
-  | 'property'
-  | 'field'
+  | "property"
+  | "field"
   | ExpressionType
   | TypeElementType
   | LiteralElementType
@@ -144,7 +152,8 @@ export const STANDLONE_EXPRESSION_TYPES: readonly StandaloneExpressionType[] = [
   "expr:parens",
   "expr:prop-access",
   "expr:template",
-  "expr:cond"
+  "expr:cond",
+  "expr:class",
 ];
 
 export function isStandaloneExpressionType(
@@ -200,10 +209,10 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:function",
   "t:predicate",
   // Infer is only allowed inside conditional extends clauses, but its technically "allowed"
-  // to be contained in a variety of placed _within_ that clause, so we're going to allow it 
+  // to be contained in a variety of placed _within_ that clause, so we're going to allow it
   // here. The blocking needs to happen in higher level objects, such as a type alias, an
   // interface declaration, or the type conditional
-  "t:infer"
+  "t:infer",
   // t:param is only used in functions so it shouldnt be included here generally.
   // t:predicate is only used as a function return type, so is not included here generally.
 ] as const;
@@ -224,6 +233,7 @@ export const STATEMENT_TYPES: readonly StatementElementType[] = [
 export const DECLARATION_TYPES: readonly DeclarationElementType[] = [
   "dclr:function",
   "dclr:var",
+  "dclr:class",
   // var-list is pretty much only allowed inside dclr:var
   // "dclr:var-list"
   // export declarataions are only allowed in the top level
@@ -270,7 +280,7 @@ export type AstNode = {
   type: ElementType;
   docs?: AstNode;
   props: any; // TODO: Make this more accurate
-  info?: Record<string, any>
+  info?: Record<string, any>;
   render: () => string;
 };
 
@@ -290,4 +300,4 @@ export type WithChildren<T> = T & {
   children?: AstNode[] | any;
 };
 
-export type ModifierType = 'public' | 'private' | 'protected';
+export type ModifierType = "public" | "private" | "protected";


### PR DESCRIPTION
This PR allows you to create classes. Like functions, there's a declaration and an expression version. The declaration version allows you to export, while the expression doesn't. The expression version allows an anonymous class, whereas the declaration doesn't. 

Similar to functions, the `<expr:statement>` does not allow a class expression, because it produces ambiguous code that would be rendered as a class declaration instead.

Similar to functions, you cannot default export a class declaration. This is because a class declaration can contain it's own export keyword, and requires a name. If a class default export is needed, then everything that can be accomplished with a declaration can be accomplished with an expression.

```typescript
// Class declaration
export class A {
}

// Class expression
const A = class {
}

// Default export of a class expression
export default class {
}
```