### PR TITLE
Add union and intersection type syntax

### DIFF
--- a/jastx-test/tests/builder-tests/union-and-intersection.test.tsx
+++ b/jastx-test/tests/builder-tests/union-and-intersection.test.tsx
@@ -1,0 +1,53 @@
+import { expect, test } from "vitest";
+
+test("<t:union> renders correctly", () => {
+  const v1 = (
+    <t:union>
+      <t:primitive type="string" />
+      <t:primitive type="number" />
+      <t:primitive type="boolean" />
+    </t:union>
+  );
+
+  expect(v1.render()).toBe("string|number|boolean");
+});
+
+test("<t:intersection> renders correctly", () => {
+  const v1 = (
+    <t:intersection>
+      <t:primitive type="string" />
+      <t:primitive type="number" />
+      <t:primitive type="boolean" />
+    </t:intersection>
+  );
+
+  expect(v1.render()).toBe("string&number&boolean");
+});
+
+test("<t:union> renders intersections without parenthesis", () => {
+  const v1 = (
+    <t:union>
+      <t:primitive type="string" />
+      <t:intersection>
+        <t:primitive type="number" />
+        <t:primitive type="boolean" />
+      </t:intersection>
+    </t:union>
+  );
+
+  expect(v1.render()).toBe("string|number&boolean");
+});
+
+test("<t:intersection> renders unions with parenthesis", () => {
+  const v1 = (
+    <t:intersection>
+      <t:primitive type="string" />
+      <t:union>
+        <t:primitive type="number" />
+        <t:primitive type="boolean" />
+      </t:union>
+    </t:intersection>
+  );
+
+  expect(v1.render()).toBe("string&(number|boolean)");
+});

--- a/jastx/src/builders/type-intersection.ts
+++ b/jastx/src/builders/type-intersection.ts
@@ -1,0 +1,50 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode, ElementType, TYPE_TYPES } from "../types.js";
+
+const type = "t:intersection";
+
+export interface TypeIntersectionProps {
+  children?: any;
+}
+
+export interface TypeIntersectionNode extends AstNode {
+  type: typeof type;
+  props: TypeIntersectionProps;
+}
+
+const allowed_types = [
+  ...TYPE_TYPES,
+  "l:bigint",
+  "l:number",
+  "l:string",
+  "l:boolean",
+] satisfies ElementType[];
+
+export function createTypeIntersection(
+  props: TypeIntersectionProps
+): TypeIntersectionNode {
+  const walker = createChildWalker(type, props);
+
+  const types = walker.spliceAssertGroup(allowed_types);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      allowed_types,
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () =>
+      `${types
+        // For type unions, we need to wrap them in parenthesis, as the intersection
+        // type has precedence, an intersection of A and the union B | C would otherwise
+        // be rendered as A & B | C, which resolves to (A & B) | C, rather than A & (B | C)
+        .map((a) => (a.type === "t:union" ? `(${a.render()})` : a.render()))
+        .join("&")}`,
+  };
+}

--- a/jastx/src/builders/type-union.ts
+++ b/jastx/src/builders/type-union.ts
@@ -1,0 +1,42 @@
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError } from "../errors.js";
+import { AstNode, ElementType, TYPE_TYPES } from "../types.js";
+
+const type = "t:union";
+
+export interface TypeUnionProps {
+  children?: any;
+}
+
+export interface TypeUnionNode extends AstNode {
+  type: typeof type;
+  props: TypeUnionProps;
+}
+
+const allowed_types = [
+  ...TYPE_TYPES,
+  "l:bigint",
+  "l:number",
+  "l:string",
+  "l:boolean",
+] satisfies ElementType[];
+
+export function createTypeUnion(props: TypeUnionProps): TypeUnionNode {
+  const walker = createChildWalker(type, props);
+
+  const types = walker.spliceAssertGroup(allowed_types);
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      allowed_types,
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type,
+    props,
+    render: () => `${types.map((a) => a.render()).join("|")}`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -170,6 +170,10 @@ import {
   TypeInterfaceProps,
 } from "./builders/type-interface.js";
 import {
+  createTypeIntersection,
+  TypeIntersectionProps,
+} from "./builders/type-intersection.js";
+import {
   createTypeLiteral,
   TypeLiteralProps,
 } from "./builders/type-literal.js";
@@ -201,6 +205,7 @@ import {
   PropertySignatureProps,
 } from "./builders/type-signatures.js";
 import { createTypeTuple, TypeTupleProps } from "./builders/type-tuple.js";
+import { createTypeUnion, TypeUnionProps } from "./builders/type-union.js";
 import {
   AwaitExpressionProps,
   createAwaitExpression,
@@ -352,6 +357,10 @@ export const jsxs = <T>(
         return createTypeAlias(options as TypeAliasProps);
       case "t:infer":
         return createTypeInfer(options as TypeInferProps);
+      case "t:union":
+        return createTypeUnion(options as TypeUnionProps);
+      case "t:intersection":
+        return createTypeIntersection(options as TypeIntersectionProps);
 
       // Expressions
       case "expr:as":
@@ -474,6 +483,8 @@ declare global {
       ["t:interface_"]: TypeInterfaceProps;
       ["t:alias"]: TypeAliasProps;
       ["t:infer"]: TypeInferProps;
+      ["t:union"]: TypeUnionProps;
+      ["t:intersection"]: TypeIntersectionProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -79,6 +79,8 @@ const _types = [
   "function",
   "interface_", // Reserved word
   "infer",
+  "union",
+  "intersection",
 
   // Signatures
   "method",
@@ -208,6 +210,8 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:query",
   "t:function",
   "t:predicate",
+  "t:union",
+  "t:intersection",
   // Infer is only allowed inside conditional extends clauses, but its technically "allowed"
   // to be contained in a variety of placed _within_ that clause, so we're going to allow it
   // here. The blocking needs to happen in higher level objects, such as a type alias, an


### PR DESCRIPTION
The union syntax combines types with a pipe
```typescript
type ExampleUnion = string | number | boolean;
```

The intersection syntax combines types with an ampersand
```typescript
type ExampleIntersection = A & B & C
```

Type intersections take precedence over unions when there is ambiguity. 
```typescript
type AmbiguousLookingType = A | B & C
// The precedence means that this is the same type as:
type RealType = A | (B & C)
```

Because of this, the intersection type will automatically render parenthesis around union types contained within its children to preserve the desired precedence

```html
<t:intersection>
  <t:primitive type="A" />
  <t:union>
    <t:primitive type="B" />
    <t:primitive type="C" />
  </t:union>
</t:intersection>
```
Renders as 
```typescript
A & (B | C)
```

The union type however does not use parenthesis when encountering intersection children
```html
<t:union>
  <t:primitive type="A" />
  <t:intersection>
    <t:primitive type="B" />
    <t:primitive type="C" />
  </t:intersection>
</t:union>
````

Renders as
```typescript
A | B & C