### PR TITLE
Fix intersection and union child ambiguities

### DIFF
--- a/jastx-test/tests/builder-tests/union-and-intersection.test.tsx
+++ b/jastx-test/tests/builder-tests/union-and-intersection.test.tsx
@@ -51,3 +51,29 @@ test("<t:intersection> renders unions with parenthesis", () => {
 
   expect(v1.render()).toBe("string&(number|boolean)");
 });
+
+test("<t:union> parenthesizes functions", () => {
+  const v1 = (
+    <t:union>
+      <t:function>
+        <t:primitive type="string" />
+      </t:function>
+      <t:primitive type="string" />
+    </t:union>
+  );
+
+  expect(v1.render()).toBe("(()=>string)|string");
+});
+
+test("<t:intersection> parenthesizes functions", () => {
+  const v1 = (
+    <t:intersection>
+      <t:function>
+        <t:primitive type="string" />
+      </t:function>
+      <t:primitive type="string" />
+    </t:intersection>
+  );
+
+  expect(v1.render()).toBe("(()=>string)&string");
+});

--- a/jastx-test/tests/builder-tests/union-and-intersection.test.tsx
+++ b/jastx-test/tests/builder-tests/union-and-intersection.test.tsx
@@ -65,6 +65,30 @@ test("<t:union> parenthesizes functions", () => {
   expect(v1.render()).toBe("(()=>string)|string");
 });
 
+test("<t:union> parenthesizes conditional", () => {
+  const v1 = (
+    <t:union>
+      <t:cond>
+        <t:ref>
+          <ident name="X" />
+        </t:ref>
+        <t:ref>
+          <ident name="Y" />
+        </t:ref>
+        <t:ref>
+          <ident name="A" />
+        </t:ref>
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </t:cond>
+      <t:primitive type="string" />
+    </t:union>
+  );
+
+  expect(v1.render()).toBe("(X extends Y?A:B)|string");
+});
+
 test("<t:intersection> parenthesizes functions", () => {
   const v1 = (
     <t:intersection>
@@ -76,4 +100,28 @@ test("<t:intersection> parenthesizes functions", () => {
   );
 
   expect(v1.render()).toBe("(()=>string)&string");
+});
+
+test("<t:intersection> parenthesizes conditional", () => {
+  const v1 = (
+    <t:intersection>
+      <t:cond>
+        <t:ref>
+          <ident name="X" />
+        </t:ref>
+        <t:ref>
+          <ident name="Y" />
+        </t:ref>
+        <t:ref>
+          <ident name="A" />
+        </t:ref>
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </t:cond>
+      <t:primitive type="string" />
+    </t:intersection>
+  );
+
+  expect(v1.render()).toBe("(X extends Y?A:B)&string");
 });

--- a/jastx/src/builders/type-intersection.ts
+++ b/jastx/src/builders/type-intersection.ts
@@ -21,6 +21,13 @@ const allowed_types = [
   "l:boolean",
 ] satisfies ElementType[];
 
+function canCauseAmbiguity(node: AstNode) {
+  // For type unions, we need to wrap them in parenthesis, as the intersection
+  // type has precedence, an intersection of A and the union B | C would otherwise
+  // be rendered as A & B | C, which resolves to (A & B) | C, rather than A & (B | C)
+  return ["t:function", "t:union", "t:cond"].includes(node.type);
+}
+
 export function createTypeIntersection(
   props: TypeIntersectionProps
 ): TypeIntersectionNode {
@@ -41,10 +48,7 @@ export function createTypeIntersection(
     props,
     render: () =>
       `${types
-        // For type unions, we need to wrap them in parenthesis, as the intersection
-        // type has precedence, an intersection of A and the union B | C would otherwise
-        // be rendered as A & B | C, which resolves to (A & B) | C, rather than A & (B | C)
-        .map((a) => (a.type === "t:union" ? `(${a.render()})` : a.render()))
+        .map((a) => (canCauseAmbiguity(a) ? `(${a.render()})` : a.render()))
         .join("&")}`,
   };
 }

--- a/jastx/src/builders/type-union.ts
+++ b/jastx/src/builders/type-union.ts
@@ -21,6 +21,10 @@ const allowed_types = [
   "l:boolean",
 ] satisfies ElementType[];
 
+function canCauseAmbiguity(node: AstNode) {
+  return ["t:function", "t:cond"];
+}
+
 export function createTypeUnion(props: TypeUnionProps): TypeUnionNode {
   const walker = createChildWalker(type, props);
 
@@ -37,6 +41,9 @@ export function createTypeUnion(props: TypeUnionProps): TypeUnionNode {
   return {
     type,
     props,
-    render: () => `${types.map((a) => a.render()).join("|")}`,
+    render: () =>
+      `${types
+        .map((a) => (canCauseAmbiguity(a) ? `(${a.render()})` : a.render()))
+        .join("|")}`,
   };
 }

--- a/jastx/src/builders/type-union.ts
+++ b/jastx/src/builders/type-union.ts
@@ -22,7 +22,7 @@ const allowed_types = [
 ] satisfies ElementType[];
 
 function canCauseAmbiguity(node: AstNode) {
-  return ["t:function", "t:cond"];
+  return ["t:function", "t:cond"].includes(node.type);
 }
 
 export function createTypeUnion(props: TypeUnionProps): TypeUnionNode {


### PR DESCRIPTION
Fixes ambiguities more generally for union and intersection types. In both cases, functions and conditional types require parenthesis as they are multi-component types.

```html
<t:union>
  <t:function>
    <t:primitive type="string" />
  </t:function>
  <t:primitive type="number" />
</t:union>
```

Before
```typescript
// Renders incorrectly as
() => string | number
// Resolves to a single function type that returns either a string or a number
```

After
```typescript
// Renders correctly as
(() => string) | number
```