### PR TITLE
Add array type

### DIFF
--- a/jastx-test/tests/builder-tests/type-array.test.tsx
+++ b/jastx-test/tests/builder-tests/type-array.test.tsx
@@ -1,0 +1,65 @@
+import { expect, test } from "vitest";
+
+test("<t:array> renders correctly with simple types", () => {
+  const v1 = (
+    <t:array>
+      <t:primitive type="string" />
+    </t:array>
+  );
+
+  expect(v1.render()).toBe("string[]");
+});
+
+test("<t:array> renders parenthesis for ambiguous types", () => {
+  const v1 = (
+    <t:array>
+      <t:union>
+        <t:primitive type="string" />
+        <t:primitive type="number" />
+        <t:primitive type="boolean" />
+      </t:union>
+    </t:array>
+  );
+
+  expect(v1.render()).toBe("(string|number|boolean)[]");
+  const v2 = (
+    <t:array>
+      <t:intersection>
+        <t:primitive type="string" />
+        <t:primitive type="number" />
+        <t:primitive type="boolean" />
+      </t:intersection>
+    </t:array>
+  );
+
+  expect(v2.render()).toBe("(string&number&boolean)[]");
+  const v3 = (
+    <t:array>
+      <t:function>
+        <t:primitive type="string" />
+      </t:function>
+    </t:array>
+  );
+
+  expect(v3.render()).toBe("(()=>string)[]");
+  const v4 = (
+    <t:array>
+      <t:cond>
+        <t:ref>
+          <ident name="X" />
+        </t:ref>
+        <t:ref>
+          <ident name="Y" />
+        </t:ref>
+        <t:ref>
+          <ident name="A" />
+        </t:ref>
+        <t:ref>
+          <ident name="B" />
+        </t:ref>
+      </t:cond>
+    </t:array>
+  );
+
+  expect(v4.render()).toBe("(X extends Y?A:B)[]");
+});

--- a/jastx/src/builders/type-array.ts
+++ b/jastx/src/builders/type-array.ts
@@ -1,0 +1,38 @@
+import { assertNChildren } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { AstNode, TYPE_TYPES } from "../types.js";
+
+const type = "t:array";
+
+export interface TypeArrayProps {
+  children: any;
+}
+
+export interface TypeArrayNode extends AstNode {
+  type: typeof type;
+  props: TypeArrayProps;
+}
+
+function canCauseAmbiguity(node: AstNode) {
+  return ["t:function", "t:union", "t:intersection", "t:cond"].includes(
+    node.type
+  );
+}
+
+export function createTypeArray(props: TypeArrayProps): TypeArrayNode {
+  assertNChildren(type, 1, props);
+
+  const walker = createChildWalker(type, props);
+  const arrayed_type = walker.spliceAssertNext([...TYPE_TYPES]);
+
+  return {
+    type,
+    props,
+    render: () =>
+      `${
+        canCauseAmbiguity(arrayed_type)
+          ? `(${arrayed_type.render()})`
+          : arrayed_type.render()
+      }[]`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -152,6 +152,7 @@ import {
   TryStatementProps,
 } from "./builders/try-statement.js";
 import { createTypeAlias, TypeAliasProps } from "./builders/type-alias.js";
+import { createTypeArray, TypeArrayProps } from "./builders/type-array.js";
 import {
   createTypeConditional,
   TypeConditionalProps,
@@ -361,6 +362,8 @@ export const jsxs = <T>(
         return createTypeUnion(options as TypeUnionProps);
       case "t:intersection":
         return createTypeIntersection(options as TypeIntersectionProps);
+      case "t:array":
+        return createTypeArray(options as TypeArrayProps);
 
       // Expressions
       case "expr:as":
@@ -485,6 +488,7 @@ declare global {
       ["t:infer"]: TypeInferProps;
       ["t:union"]: TypeUnionProps;
       ["t:intersection"]: TypeIntersectionProps;
+      ["t:array"]: TypeArrayProps;
 
       ["ident"]: IdentifierProps;
       ["block"]: BlockProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -81,6 +81,7 @@ const _types = [
   "infer",
   "union",
   "intersection",
+  "array",
 
   // Signatures
   "method",
@@ -212,6 +213,7 @@ export const TYPE_TYPES: readonly TypeElementType[] = [
   "t:predicate",
   "t:union",
   "t:intersection",
+  "t:array",
   // Infer is only allowed inside conditional extends clauses, but its technically "allowed"
   // to be contained in a variety of placed _within_ that clause, so we're going to allow it
   // here. The blocking needs to happen in higher level objects, such as a type alias, an


### PR DESCRIPTION
Array type syntax just adds the square brackets to a value
```typescript
// Array type on string
type StringArray = string[];
// Array type on ref
type OtherArray = T[];
```

Function types, conditional types, union types, and intersection types can all cause ambiguous rendering issues, so they are all parethesized during the render.

```typescript
type FunctionArray = (() => string)[];
type ConditionalArray = (X extends Y ? A : B)[];
type UnionArray = (string | number)[];
type IntersectionArray = (string & number)[];
```