### PR TITLE
Add import syntax

### DIFF
--- a/jastx-test/tests/builder-tests/imports.test.tsx
+++ b/jastx-test/tests/builder-tests/imports.test.tsx
@@ -1,0 +1,166 @@
+import { expect, test } from "vitest";
+
+test("<import-specifier> renders correctly as an identifier", () => {
+  const v1 = (
+    <import-specifier>
+      <ident name="a" />
+    </import-specifier>
+  );
+  expect(v1.render()).toBe("a");
+});
+
+test("<import-specifier> renders correctly with an alias", () => {
+  const v1 = (
+    <import-specifier>
+      <ident name="a" />
+      <ident name="b" />
+    </import-specifier>
+  );
+  expect(v1.render()).toBe("a as b");
+});
+
+test("<import-specifier> renders correctly as type only", () => {
+  const v1 = (
+    <import-specifier typeOnly>
+      <ident name="a" />
+    </import-specifier>
+  );
+  expect(v1.render()).toBe("type a");
+
+  const v2 = (
+    <import-specifier typeOnly>
+      <ident name="a" />
+      <ident name="b" />
+    </import-specifier>
+  );
+  expect(v2.render()).toBe("type a as b");
+});
+
+test("<named-imports> renders correctly with a single import specifier", () => {
+  const v1 = (
+    <named-imports>
+      <import-specifier>
+        <ident name="a" />
+      </import-specifier>
+    </named-imports>
+  );
+  expect(v1.render()).toBe("{a}");
+});
+
+test("<named-imports> renders correctly with just an identifier", () => {
+  const v1 = (
+    <named-imports>
+      <ident name="a" />
+    </named-imports>
+  );
+  expect(v1.render()).toBe("{a}");
+});
+
+test("<named-imports> renders correctly with multiple imports", () => {
+  const v1 = (
+    <named-imports>
+      <ident name="a" />
+      <import-specifier>
+        <ident name="b" />
+      </import-specifier>
+    </named-imports>
+  );
+  expect(v1.render()).toBe("{a,b}");
+});
+
+test("<named-imports> renders correctly with mixed type and non-type imports", () => {
+  const v1 = (
+    <named-imports>
+      <ident name="a" />
+      <import-specifier typeOnly>
+        <ident name="b" />
+      </import-specifier>
+      <import-specifier>
+        <ident name="c" />
+      </import-specifier>
+    </named-imports>
+  );
+  expect(v1.render()).toBe("{a,type b,c}");
+});
+
+test("<namespace-import> renders correctly with a single alias", () => {
+  const v1 = (
+    <namespace-import>
+      <ident name="a" />
+    </namespace-import>
+  );
+  expect(v1.render()).toBe("* as a");
+});
+
+test("<dclr:import> renders correctly with named-imports", () => {
+  const v1 = (
+    <dclr:import>
+      <named-imports>
+        <ident name="a" />
+        <import-specifier typeOnly>
+          <ident name="b" />
+        </import-specifier>
+      </named-imports>
+      <l:string value="./test" />
+    </dclr:import>
+  );
+  expect(v1.render()).toBe('import {a,type b} from "./test"');
+});
+
+test("<dclr:import> renders correctly with a namespace import alias", () => {
+  const v1 = (
+    <dclr:import>
+      <namespace-import>
+        <ident name="X" />
+      </namespace-import>
+      <l:string value="./test" />
+    </dclr:import>
+  );
+  expect(v1.render()).toBe('import * as X from "./test"');
+});
+
+test("<dclr:import> renders correctly with both a default import and named imports", () => {
+  const v1 = (
+    <dclr:import>
+      <ident name="X" />
+      <named-imports>
+        <ident name="a" />
+        <import-specifier typeOnly>
+          <ident name="b" />
+        </import-specifier>
+      </named-imports>
+      <l:string value="./test" />
+    </dclr:import>
+  );
+  expect(v1.render()).toBe('import X,{a,type b} from "./test"');
+});
+
+test("<dclr:import> renders correctly with both a default import and a namespace import", () => {
+  const v1 = (
+    <dclr:import>
+      <ident name="X" />
+      <namespace-import>
+        <ident name="Q" />
+      </namespace-import>
+      <l:string value="./test" />
+    </dclr:import>
+  );
+  expect(v1.render()).toBe('import X,* as Q from "./test"');
+});
+
+test("<dclr:import> renders correctly with import attributes", () => {
+  const v1 = (
+    <dclr:import>
+      <ident name="X" />
+      <namespace-import>
+        <ident name="Q" />
+      </namespace-import>
+      <l:string value="./test" />
+      <import-attribute>
+        <ident name="type" />
+        <l:string value="json" />
+      </import-attribute>
+    </dclr:import>
+  );
+  expect(v1.render()).toBe('import X,* as Q from "./test" with {type:"json"}');
+});

--- a/jastx/src/builders/imports.ts
+++ b/jastx/src/builders/imports.ts
@@ -1,0 +1,211 @@
+import { assertMaxChildren, assertNChildren, assertValue } from "../asserts.js";
+import { createChildWalker } from "../child-walker.js";
+import { InvalidChildrenError, InvalidSyntaxError } from "../errors.js";
+import { AstNode } from "../types.js";
+
+const spec_type = "import-specifier";
+
+export interface ImportSpecifierProps {
+  children: any;
+  typeOnly?: boolean;
+}
+
+export interface ImportSpecifierNode extends AstNode {
+  type: typeof spec_type;
+  props: ImportSpecifierProps;
+}
+
+export function createImportSpecifier(
+  props: ImportSpecifierProps
+): ImportSpecifierNode {
+  assertMaxChildren(spec_type, 2, props);
+  const { typeOnly = false } = props;
+
+  const walker = createChildWalker(spec_type, props);
+
+  const [ident, alias] = walker.spliceAssertExactPath(
+    ["ident", ["ident", null]],
+    {
+      noTrailing: true,
+    }
+  );
+
+  assertValue(ident);
+
+  return {
+    type: spec_type,
+    props,
+    render: () =>
+      `${typeOnly ? "type " : ""}${ident.render()}${
+        alias ? ` as ${alias.render()}` : ""
+      }`,
+  };
+}
+
+const ni_type = "named-imports";
+
+export interface NamedImportsProps {
+  children: any;
+}
+
+export interface NamedImportsNode extends AstNode {
+  type: typeof ni_type;
+  props: NamedImportsProps;
+}
+
+export function createNamedImports(props: NamedImportsProps): NamedImportsNode {
+  const walker = createChildWalker(ni_type, props);
+
+  const import_values = walker.spliceAssertGroup(
+    ["ident", "import-specifier"],
+    { size: [1, undefined] }
+  );
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      ni_type,
+      ["ident", "import-specifier"],
+      walker.remainingChildTypes
+    );
+  }
+
+  return {
+    type: ni_type,
+    props,
+    render: () => `{${import_values.map((x) => x.render()).join(",")}}`,
+  };
+}
+
+const ns_type = "namespace-import";
+
+export interface NamespaceImportProps {
+  children: any;
+}
+
+export interface NamespaceImportNode extends AstNode {
+  type: typeof ns_type;
+  props: NamespaceImportProps;
+}
+
+export function createNamespaceImport(
+  props: NamespaceImportProps
+): NamespaceImportNode {
+  assertNChildren(ns_type, 1, props);
+
+  const walker = createChildWalker(ns_type, props);
+
+  const import_name = walker.spliceAssertNext("ident");
+
+  return {
+    type: ns_type,
+    props,
+    render: () => `* as ${import_name.render()}`,
+  };
+}
+
+const att_type = "import-attribute";
+
+export interface ImportAttributeProps {
+  children: any;
+}
+
+export interface ImportAttributeNode extends AstNode {
+  type: typeof att_type;
+  props: ImportAttributeProps;
+}
+
+export function createImportAttribute(
+  props: ImportAttributeProps
+): ImportAttributeNode {
+  assertNChildren(att_type, 2, props);
+
+  const walker = createChildWalker(att_type, props);
+  const [ident, value] = walker.spliceAssertExactPath(["ident", "l:string"]);
+
+  assertValue(ident);
+  assertValue(value);
+
+  return {
+    type: att_type,
+    props,
+    render: () => `${ident.render()}:${value.render()}`,
+  };
+}
+
+const type = "dclr:import";
+
+export interface ImportDeclarationProps {
+  children: any;
+  typeOnly?: boolean;
+}
+
+export interface ImportDeclarationNode extends AstNode {
+  type: typeof type;
+  props: ImportDeclarationProps;
+}
+
+export function isImportDeclaration(
+  node: AstNode
+): node is ImportDeclarationNode {
+  return node.type === type;
+}
+
+export function createImportDeclaration(
+  props: ImportDeclarationProps
+): ImportDeclarationNode {
+  const { typeOnly = false } = props;
+
+  const walker = createChildWalker(type, props);
+
+  const [default_value, values, source] = walker.spliceAssertExactPath(
+    [
+      ["ident", null],
+      ["named-imports", "namespace-import", null],
+      ["l:string"],
+    ],
+    { noTrailing: false }
+  );
+
+  assertValue(source);
+
+  const import_attributes = walker.spliceAssertGroup("import-attribute");
+
+  if (walker.remainingChildren.length > 0) {
+    throw new InvalidChildrenError(
+      type,
+      [
+        "ident",
+        "named-imports",
+        "namespace-import",
+        "l:string",
+        "import-attribute",
+      ],
+      walker.remainingChildTypes
+    );
+  }
+
+  const render_clause = () => {
+    if (default_value && values) {
+      return `${default_value.render()},${values.render()}`;
+    } else if (default_value) {
+      return default_value.render();
+    } else if (values) {
+      return values.render();
+    }
+
+    return ``;
+  };
+
+  return {
+    type,
+    props,
+    render: () =>
+      `import${
+        typeOnly ? " type " : " "
+      }${render_clause()} from ${source.render()}${
+        import_attributes.length > 0
+          ? ` with {${import_attributes.map((x) => x.render()).join(",")}}`
+          : ""
+      }`,
+  };
+}

--- a/jastx/src/jsx-runtime.ts
+++ b/jastx/src/jsx-runtime.ts
@@ -100,6 +100,18 @@ import {
   IfStatementProps,
 } from "./builders/if-statement.js";
 import {
+  createImportAttribute,
+  createImportDeclaration,
+  createImportSpecifier,
+  createNamedImports,
+  createNamespaceImport,
+  ImportAttributeProps,
+  ImportDeclarationProps,
+  ImportSpecifierProps,
+  NamedImportsProps,
+  NamespaceImportProps,
+} from "./builders/imports.js";
+import {
   ArrayLiteralProps,
   BigintLiteralProps,
   BooleanLiteralProps,
@@ -291,6 +303,14 @@ export const jsxs = <T>(
         return createMethod(options as MethodProps);
       case "field":
         return createField(options as FieldProps);
+      case "named-imports":
+        return createNamedImports(options as NamedImportsProps);
+      case "namespace-import":
+        return createNamespaceImport(options as NamespaceImportProps);
+      case "import-specifier":
+        return createImportSpecifier(options as ImportSpecifierProps);
+      case "import-attribute":
+        return createImportAttribute(options as ImportAttributeProps);
 
       // Declarations
       case "dclr:function":
@@ -306,6 +326,8 @@ export const jsxs = <T>(
         return createExportDeclaration(options as ExportDeclarationProps);
       case "dclr:class":
         return createClassDeclaration(options as ClassDeclarationProps);
+      case "dclr:import":
+        return createImportDeclaration(options as ImportDeclarationProps);
 
       // Literal values
       case "l:boolean":
@@ -506,12 +528,17 @@ declare global {
       ["set-accessor"]: SetAccessorProps;
       ["method"]: MethodProps;
       ["field"]: FieldProps;
+      ["named-imports"]: NamedImportsProps;
+      ["namespace-import"]: NamespaceImportProps;
+      ["import-specifier"]: ImportSpecifierProps;
+      ["import-attribute"]: ImportAttributeProps;
 
       ["dclr:function"]: FunctionDeclarationProps;
       ["dclr:var"]: VariableDeclarationProps;
       ["dclr:var-list"]: VariableDeclarationListProps;
       ["dclr:export"]: ExportDeclarationProps;
       ["dclr:class"]: ClassDeclarationProps;
+      ["dclr:import"]: ImportDeclarationProps;
 
       ["stmt:if"]: IfStatementProps;
       ["stmt:expr"]: ExpressionStatementProps;

--- a/jastx/src/types.ts
+++ b/jastx/src/types.ts
@@ -114,8 +114,8 @@ const _declarations = [
   "var",
   "var-list",
   "export",
-  "property",
   "class",
+  "import",
 ] as const;
 
 export type DeclarationElementTypeName = (typeof _declarations)[number];
@@ -132,6 +132,10 @@ export type ElementType =
   | "named-exports"
   | "namespace-export"
   | "export-default"
+  | "import-specifier"
+  | "named-imports"
+  | "namespace-import"
+  | "import-attribute"
   | "heritage-clause"
   | "heritage-ident"
   | "bind:array"
@@ -249,6 +253,7 @@ export const DECLARATION_TYPES: readonly DeclarationElementType[] = [
 export const TOP_LEVEL_DECLARATION_TYPES: readonly DeclarationElementType[] = [
   ...DECLARATION_TYPES,
   "dclr:export",
+  "dclr:import",
 ];
 
 export function omitFrom(


### PR DESCRIPTION
The import syntax supports quite a variety of different import kinds, some shown below

```typescript
import 'module';
import A from 'module';
import * as L from 'module';
import type DXXX, * as Q from 'module'
import { C as D } from 'module';
import type G from 'module';
import type * as K from 'module';
import type { H } from 'module';
import { type I } from 'module';
import J from 'module' with { type: 'json' };
```